### PR TITLE
Feature/message queue test

### DIFF
--- a/context.go
+++ b/context.go
@@ -34,6 +34,14 @@ type Context struct {
 	LogFrames              bool               // If true, will log about frames (very verbose)
 }
 
+// Defines a logging interface for use within the blip codebase.  Implemented by Context.
+// Any code that needs to take a Context just for logging purposes should take a Logger instead.
+type LogContext interface {
+	log(fmt string, params ...interface{})
+	logMessage(fmt string, params ...interface{})
+	logFrame(fmt string, params ...interface{})
+}
+
 //////// SETUP:
 
 // Creates a new Context with an empty dispatch table.

--- a/messagequeue.go
+++ b/messagequeue.go
@@ -143,6 +143,12 @@ func (q *messageQueue) nextMessageIsUrgent() bool {
 	return len(q.queue) > 0 && q.queue[0].Urgent()
 }
 
+func (q *messageQueue) length() int {
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
+	return len(q.queue)
+}
+
 // Returns statistics about the number of incoming and outgoing messages queued.
 func (q *messageQueue) backlog() (outgoingRequests, outgoingResponses int) {
 	q.cond.L.Lock()

--- a/messagequeue.go
+++ b/messagequeue.go
@@ -39,7 +39,7 @@ func (q *messageQueue) _push(msg *Message, new bool) bool { // requires lock
 	if msg.Urgent() && n > 1 {
 		// High-priority gets queued after the last existing high-priority message,
 		// leaving one regular-priority message in between if possible.
-		for index = n - 1; index > 0; index-- {
+		for index = n - 1; index >= 0; index-- {
 			if q.queue[index].Urgent() {
 				index += 2
 				break
@@ -49,7 +49,7 @@ func (q *messageQueue) _push(msg *Message, new bool) bool { // requires lock
 				break
 			}
 		}
-		if index == 0 {
+		if index <= 0 {
 			index = 1
 		} else if index > n {
 			index = n

--- a/messagequeue_test.go
+++ b/messagequeue_test.go
@@ -130,7 +130,7 @@ func TestConcurrentAccess(t *testing.T) {
 // T5: [n5] [n4] [n3] [n2] [n1]
 // T5: [n5] [n4] [n3] [n2] [u6] [n1]
 // T6: [n5] [n4] [n3] [n2] [u6]
-// T7: See comments below, there is a delta between expected and actual
+// T7: [n5] [n4] [n3] [u7] [n2] [u6]
 
 func TestUrgentMessageOrdering(t *testing.T) { // Test passes, but some assertions commented
 
@@ -188,26 +188,14 @@ func TestUrgentMessageOrdering(t *testing.T) { // Test passes, but some assertio
 	assert.True(t, headOfLine.Urgent())
 	assert.True(t, headOfLine.SerialNumber() == urgentMsg.SerialNumber())
 
-	// The rest of the assertions don't work
-	// Expected T7: [n5] [n4] [n3] [u7] [n2] [u6]
-	// Actual T7: [n5] [n4] [n3] [n2] [u7] [u6]
-	//
-	// The expected T7 is based on the statement "If there are one or more normal messages after that one,
-	// the message is inserted after the first normal message (this prevents normal messages from being
-	// starved and never reaching the head of the queue.)".  Is it behaving as expected, or am I confused
-	// about the statement?  (actually, the statement might be more clear if "that one" was replaced by
-	// more descriptive wording)
-
 	// Followed by a normal message, since the second urgent message should have been placed _after_ a normal message
 	headOfLine = mq.pop()
-	// TODO: assertion fails due to reasons above
-	// assert.False(t, headOfLine.Urgent())
+	assert.False(t, headOfLine.Urgent())
 
 	// Followed by the less urgent message
 	headOfLine = mq.pop()
-	// TODO: assertion fails due to reasons above
-	// assert.True(t, headOfLine.Urgent())
-	// assert.True(t, headOfLine.SerialNumber() == anotherUrgentMsg.SerialNumber())
+	assert.True(t, headOfLine.Urgent())
+	assert.True(t, headOfLine.SerialNumber() == anotherUrgentMsg.SerialNumber())
 
 	// Followed by 3 normal messages
 	headOfLine = mq.pop()
@@ -219,7 +207,6 @@ func TestUrgentMessageOrdering(t *testing.T) { // Test passes, but some assertio
 
 	// Now the queue should be empty
 	assert.True(t, mq.length() == 0)
-
 }
 
 type TestLogContext struct{}

--- a/messagequeue_test.go
+++ b/messagequeue_test.go
@@ -1,12 +1,12 @@
 package blip
 
 import (
+	"bytes"
 	"log"
+	"sync"
 	"testing"
 
 	"github.com/couchbaselabs/go.assert"
-	"sync"
-	"bytes"
 )
 
 func TestMessagePushPop(t *testing.T) {
@@ -56,7 +56,6 @@ func TestMessagePushPop(t *testing.T) {
 
 	// Assert that it's empty at this point
 	assert.True(t, mq.length() == 0)
-
 
 }
 
@@ -133,7 +132,7 @@ func TestConcurrentAccess(t *testing.T) {
 // T6: [n5] [n4] [n3] [n2] [u6]
 // T7: See comments below, there is a delta between expected and actual
 
-func TestUrgentMessageOrdering(t *testing.T) {  // Test passes, but some assertions commented
+func TestUrgentMessageOrdering(t *testing.T) { // Test passes, but some assertions commented
 
 	// Create a message queue
 	maxSendQueueCount := 25
@@ -221,10 +220,7 @@ func TestUrgentMessageOrdering(t *testing.T) {  // Test passes, but some asserti
 	// Now the queue should be empty
 	assert.True(t, mq.length() == 0)
 
-
 }
-
-
 
 type TestLogContext struct{}
 

--- a/messagequeue_test.go
+++ b/messagequeue_test.go
@@ -1,0 +1,241 @@
+package blip
+
+import (
+	"log"
+	"testing"
+
+	"github.com/couchbaselabs/go.assert"
+	"sync"
+	"bytes"
+)
+
+func TestMessagePushPop(t *testing.T) {
+
+	// Create a message queue
+	maxSendQueueCount := 5
+	mq := newMessageQueue(TestLogContext{}, maxSendQueueCount)
+
+	// Push a non-urgent message into the queue
+	for i := 0; i < 2; i++ {
+		msg := NewRequest()
+		pushed := mq.push(msg)
+		assert.True(t, pushed)
+		assert.False(t, mq.nextMessageIsUrgent())
+		if i == 0 {
+			assert.True(t, mq.first().SerialNumber() == msg.SerialNumber())
+		}
+	}
+
+	// Push an urgent message into the queue
+	urgentMsg := NewRequest()
+	urgentMsg.SetUrgent(true)
+	pushed := mq.push(urgentMsg)
+	assert.True(t, pushed)
+
+	// Since none of the normal messages have had any frames sent
+	// per https://github.com/couchbaselabs/BLIP-Cpp/blob/master/docs/BLIP%20Protocol.md#32-sending-messages,
+	// the urgent message should _not_ skip to the head of the queue, and so the first message popped from the
+	// queue should be the first nomrmal message that was added to the queue
+	assert.True(t, mq.first().SerialNumber() == MessageNumber(1))
+
+	// Try to find the urgent message by it's serial number
+	foundMsg := mq.find(urgentMsg.SerialNumber(), RequestType)
+	assert.True(t, foundMsg != nil)
+	assert.True(t, foundMsg.Urgent())
+
+	// Pop the normal messages from the queue
+	for i := 0; i < 2; i++ {
+		mq.pop()
+	}
+
+	// Now the next message should be the urgent message
+	assert.True(t, mq.nextMessageIsUrgent())
+
+	// Pop the urgent message from the queue
+	mq.pop()
+
+	// Assert that it's empty at this point
+	assert.True(t, mq.length() == 0)
+
+
+}
+
+func TestConcurrentAccess(t *testing.T) {
+
+	// Create a message queue
+	maxSendQueueCount := 5
+	mq := newMessageQueue(TestLogContext{}, maxSendQueueCount)
+
+	// Fill it up to capacity w/ normal messages
+	for i := 0; i < maxSendQueueCount; i++ {
+		msg := NewRequest()
+		pushed := mq.push(msg)
+		assert.True(t, pushed)
+		assert.False(t, mq.nextMessageIsUrgent())
+	}
+
+	doneWg := sync.WaitGroup{}
+	doneWg.Add(2)
+	pusher := func() {
+		for i := 0; i < 100; i++ {
+			msg := NewRequest()
+			pushed := mq.push(msg)
+			assert.True(t, pushed)
+		}
+		doneWg.Done()
+	}
+	go pusher()
+
+	popper := func() {
+		for i := 0; i < 100; i++ {
+			mq.pop()
+		}
+		doneWg.Done()
+	}
+	go popper()
+
+	doneWg.Wait()
+
+	// Empty the queue
+	for i := 0; i < maxSendQueueCount; i++ {
+		mq.pop()
+	}
+
+	// Assert that it's empty at this point
+	assert.True(t, mq.length() == 0)
+
+}
+
+// From https://github.com/couchbaselabs/BLIP-Cpp/blob/master/docs/BLIP%20Protocol.md#32-sending-messages:
+//
+// An urgent message is placed after the last other urgent message in the queue.
+//
+// If there are one or more normal messages after that one, the message is inserted after the first normal
+// message (this prevents normal messages from being starved and never reaching the head of the queue.)
+// Or if there are no urgent messages in the queue, the message is placed after the first normal message.
+// If there are no messages at all, then there's only one place to put the message, of course.
+//
+// When a newly-ready urgent message is being added to the queue for the first time (in step 1 above),
+// it has the additional restriction that it must go after any other message that has not yet had any
+// of its frames sent. (This is so that messages are begun in sequential order; otherwise the first
+// frame of urgent message number 10 might be sent before the first frame of regular message number 8,
+// for example.)
+//
+//
+// Time  Queue (head is far right)
+// ----  -------------------------
+// T1: [n1]
+// T2: [n2] [n1]
+// T3: [n3] [n2] [n1]
+// T4: [n4] [n3] [n2] [n1]
+// T5: [n5] [n4] [n3] [n2] [n1]
+// T5: [n5] [n4] [n3] [n2] [u6] [n1]
+// T6: [n5] [n4] [n3] [n2] [u6]
+// T7: See comments below, there is a delta between expected and actual
+
+func TestUrgentMessageOrdering(t *testing.T) {  // Test passes, but some assertions commented
+
+	// Create a message queue
+	maxSendQueueCount := 25
+	mq := newMessageQueue(TestLogContext{}, maxSendQueueCount)
+
+	// Add normal messages that are "in-progress" since they have a non-nil msg.encoder
+	for i := 0; i < 5; i++ {
+		msg := NewRequest()
+		pushed := mq.push(msg)
+		assert.True(t, pushed)
+		assert.False(t, mq.nextMessageIsUrgent())
+
+		// set the msg.encoder to something so that the next urgent message will go to the head of the line
+		msg.encoder = &bytes.Buffer{}
+
+	}
+
+	// The head of the queue should be a normal message with serial number 1 (n1)
+	assert.True(t, mq.first().SerialNumber() == MessageNumber(1))
+
+	// Push an urgent message into the queue
+	urgentMsg := NewRequest()
+	urgentMsg.SetUrgent(true)
+	pushed := mq.push(urgentMsg)
+	assert.True(t, pushed)
+
+	// T5: [n5] [n4] [n3] [n2] [u6] [n1]
+	// Since there are normal messages in the queue, the urgent message should be inserted _after_ the
+	// the first normal message (to prevent normal messages from being starved and never reaching the head of the queue),
+	// so head of the queue should _still_ be a normal message with serial number 1 (n1)
+	assert.True(t, mq.first().SerialNumber() == MessageNumber(1))
+	assert.False(t, mq.first().Urgent())
+
+	// Pop the normal message from the head of the queue
+	mq.pop()
+
+	// T6: [n5] [n4] [n3] [n2] [u6]
+	// Since all the normal messages have had frames sent (faked, via non-nil msg.encoder), then the
+	// urgent message should have skipped to the head of the line
+	// assert.True(t, mq.nextMessageIsUrgent())
+	headOfLine := mq.first()
+	assert.True(t, headOfLine.Urgent())
+
+	// Push another urgent message
+	// T7: [n5] [n4] [n3] [u7] [n2] [u6]
+	anotherUrgentMsg := NewRequest()
+	anotherUrgentMsg.SetUrgent(true)
+	pushed = mq.push(anotherUrgentMsg)
+	assert.True(t, pushed)
+
+	// The head of the queue should be the first urgent message
+	headOfLine = mq.pop()
+	assert.True(t, headOfLine.Urgent())
+	assert.True(t, headOfLine.SerialNumber() == urgentMsg.SerialNumber())
+
+	// The rest of the assertions don't work
+	// Expected T7: [n5] [n4] [n3] [u7] [n2] [u6]
+	// Actual T7: [n5] [n4] [n3] [n2] [u7] [u6]
+	//
+	// The expected T7 is based on the statement "If there are one or more normal messages after that one,
+	// the message is inserted after the first normal message (this prevents normal messages from being
+	// starved and never reaching the head of the queue.)".  Is it behaving as expected, or am I confused
+	// about the statement?  (actually, the statement might be more clear if "that one" was replaced by
+	// more descriptive wording)
+
+	// Followed by a normal message, since the second urgent message should have been placed _after_ a normal message
+	headOfLine = mq.pop()
+	// TODO: assertion fails due to reasons above
+	// assert.False(t, headOfLine.Urgent())
+
+	// Followed by the less urgent message
+	headOfLine = mq.pop()
+	// TODO: assertion fails due to reasons above
+	// assert.True(t, headOfLine.Urgent())
+	// assert.True(t, headOfLine.SerialNumber() == anotherUrgentMsg.SerialNumber())
+
+	// Followed by 3 normal messages
+	headOfLine = mq.pop()
+	assert.False(t, headOfLine.Urgent())
+	headOfLine = mq.pop()
+	assert.False(t, headOfLine.Urgent())
+	headOfLine = mq.pop()
+	assert.False(t, headOfLine.Urgent())
+
+	// Now the queue should be empty
+	assert.True(t, mq.length() == 0)
+
+
+}
+
+
+
+type TestLogContext struct{}
+
+func (tlc TestLogContext) log(fmt string, params ...interface{}) {
+	log.Printf(fmt, params...)
+}
+
+func (tlc TestLogContext) logMessage(fmt string, params ...interface{}) {
+	log.Printf(fmt, params...)
+}
+
+func (tlc TestLogContext) logFrame(fmt string, params ...interface{}) {
+	log.Printf(fmt, params...)
+}

--- a/sender.go
+++ b/sender.go
@@ -38,7 +38,7 @@ func newSender(context *Context, conn *websocket.Conn, receiver *receiver) *Send
 		context:  context,
 		conn:     conn,
 		receiver: receiver,
-		queue:    newMessageQueue(context),
+		queue:    newMessageQueue(context, context.MaxSendQueueCount),
 		icebox:   map[msgKey]*Message{},
 	}
 }


### PR DESCRIPTION
While browsing the go-blip code I was reading over messagequeue and noticed there weren't any tests.  Since the spec on the messagequeue behavior had some complexities regarding urgent message ordering, I decided to write some unit tests to validate the expected behavior.

I ran into an issue where either I'm not understanding the spec, or it's not working to spec.  More details are in the comments -- search for "The rest of the assertions don't work"

- Adds unit tests 
- Minor refactoring to make it easier to test w/ a self-contained unit test -- removes dependency on `blip.Context` and instead introduces a smaller interface to pass in the logging context, which was the main thing that this code needed from `blip.Context`, aside from the queue size, which is now passed in as a separate parameter.