### PR TITLE
Feature/fix ci build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,4 +2,4 @@ build:
   image: golang:1.9.2
   commands:
     - go get -t
-    - go test
+    - go test -v

--- a/codec_test.go
+++ b/codec_test.go
@@ -28,6 +28,42 @@ func init() {
 	}
 }
 
+func TestCompressDecompress(t *testing.T) {
+	testCompressDecompress(t, []byte("hello"))
+}
+
+func TestCompressDecompressManySizes(t *testing.T) {
+	for size := 0; size <= 65535; size += 1 {
+		t.Run(fmt.Sprintf("%d", size), func(t *testing.T) {
+			t.Parallel()
+			testCompressDecompress(t, compressibleDataOfLength(size))
+		})
+	}
+}
+
+// Make sure that the decompressor returns an error with completely invalid input
+func TestDecompressInvalidInput(t *testing.T) {
+
+	decompressor := getDecompressor()
+	decompressedBytes, err := decompressor.decompress([]byte("junk_input"), 2)
+	assert.True(t, err != nil)
+	assert.True(t, len(decompressedBytes) == 0)
+
+}
+
+// Make sure that the decompressor returns an error with valid compressed input, but an invalid checksum
+func TestDecompressInvalidChecksum(t *testing.T) {
+
+	// Compress some data
+	compressedData, checksum := testCompressData(t, []byte("uncompressed"))
+
+	decompressor := getDecompressor()
+	decompressedBytes, err := decompressor.decompress([]byte(compressedData), checksum * 2)
+	assert.True(t, err != nil)
+	assert.True(t, len(decompressedBytes) == 0)
+
+}
+
 func testCompressData(t *testing.T, dataToCompress []byte) (compressedData []byte, checksum uint32) {
 
 	// Compress some data
@@ -64,40 +100,4 @@ func testCompressDecompress(t *testing.T, dataToCompress []byte) {
 
 func compressibleDataOfLength(lengthToCompress int) []byte {
 	return randomData[0:lengthToCompress]
-}
-
-func TestCompressDecompress(t *testing.T) {
-	testCompressDecompress(t, []byte("hello"))
-}
-
-func TestCompressDecompressManySizes(t *testing.T) {
-	for size := 0; size <= 65535; size += 1 {
-		t.Run(fmt.Sprintf("%d", size), func(t *testing.T) {
-			t.Parallel()
-			testCompressDecompress(t, compressibleDataOfLength(size))
-		})
-	}
-}
-
-// Make sure that the decompressor returns an error with completely invalid input
-func TestDecompressInvalidInput(t *testing.T) {
-
-	decompressor := getDecompressor()
-	decompressedBytes, err := decompressor.decompress([]byte("junk_input"), 2)
-	assert.True(t, err != nil)
-	assert.True(t, len(decompressedBytes) == 0)
-
-}
-
-// Make sure that the decompressor returns an error with valid compressed input, but an invalid checksum
-func TestDecompressInvalidChecksum(t *testing.T) {
-
-	// Compress some data
-	compressedData, checksum := testCompressData(t, []byte("uncompressed"))
-
-	decompressor := getDecompressor()
-	decompressedBytes, err := decompressor.decompress([]byte(compressedData), checksum * 2)
-	assert.True(t, err != nil)
-	assert.True(t, len(decompressedBytes) == 0)
-
 }

--- a/codec_test.go
+++ b/codec_test.go
@@ -28,7 +28,8 @@ func init() {
 	}
 }
 
-func testCompressDecompress(t *testing.T, dataToCompress []byte) {
+func testCompressData(t *testing.T, dataToCompress []byte) (compressedData []byte, checksum uint32) {
+
 	// Compress some data
 	compressedDest := bytes.Buffer{}
 	compressor := getCompressor(&compressedDest)
@@ -36,9 +37,17 @@ func testCompressDecompress(t *testing.T, dataToCompress []byte) {
 	n, err := compressor.write([]byte(dataToCompress))
 	assert.Equals(t, n, len(dataToCompress))
 	assert.True(t, err == nil)
-	compressedData := compressedDest.Bytes()
-	checksum := compressor.getChecksum()
+	compressedData = compressedDest.Bytes()
+	checksum = compressor.getChecksum()
 	returnCompressor(compressor)
+
+	return compressedData, checksum
+}
+
+func testCompressDecompress(t *testing.T, dataToCompress []byte) {
+
+	// Compress some data
+	compressedData, checksum := testCompressData(t, dataToCompress)
 
 	// fmt.Printf("Compressed %4d bytes to %4d (%.3f)\n", len(dataToCompress), len(compressedData),
 	//     float32(len(compressedData))/float32(len(dataToCompress)))
@@ -62,10 +71,33 @@ func TestCompressDecompress(t *testing.T) {
 }
 
 func TestCompressDecompressManySizes(t *testing.T) {
-	for size := 1; size <= 65535; size += 1 {
+	for size := 0; size <= 65535; size += 1 {
 		t.Run(fmt.Sprintf("%d", size), func(t *testing.T) {
 			t.Parallel()
 			testCompressDecompress(t, compressibleDataOfLength(size))
 		})
 	}
+}
+
+// Make sure that the decompressor returns an error with completely invalid input
+func TestDecompressInvalidInput(t *testing.T) {
+
+	decompressor := getDecompressor()
+	decompressedBytes, err := decompressor.decompress([]byte("junk_input"), 2)
+	assert.True(t, err != nil)
+	assert.True(t, len(decompressedBytes) == 0)
+
+}
+
+// Make sure that the decompressor returns an error with valid compressed input, but an invalid checksum
+func TestDecompressInvalidChecksum(t *testing.T) {
+
+	// Compress some data
+	compressedData, checksum := testCompressData(t, []byte("uncompressed"))
+
+	decompressor := getDecompressor()
+	decompressedBytes, err := decompressor.decompress([]byte(compressedData), checksum * 2)
+	assert.True(t, err != nil)
+	assert.True(t, len(decompressedBytes) == 0)
+
 }


### PR DESCRIPTION


Fixes the issue where Drone CI builds were failing: http://drone.couchbase.io/couchbase/go-blip/42, possibly due to starting too many parallel goroutines in the test (65K)

Also, I noticed that running that test locally was freezing up my IDE for several seconds.  

I changed it to:

- Test boundary values and 1K random sizes for compression/decompression string lengths
- More verbose logging if there is an assertion failure
- Verbose test output for Drone CI test to show which tests are running