### PR TITLE
Fixed zero-length decompress, improved logging, improved tests

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -10,6 +10,9 @@ import (
 	"sync"
 )
 
+// The standard trailer appended by 'deflate' when flushing its output. BLIP (like many protocols)
+// suppresses this in the transmitted data. The compressor removes the last 4 bytes ofoutput,
+// and the decompressor appends the trailer to its input.
 const deflateTrailer = "\x00\x00\xff\xff"
 const deflateTrailerLength = 4
 
@@ -56,7 +59,10 @@ func (c *compressor) write(data []byte) (n int, err error) {
 		n, err = c.z.Write(data)
 		if err == nil {
 			c.z.Flush()
-			// Remove the '00 00 FF FF' trailer from the deflated block
+			// Remove the '00 00 FF FF' trailer from the deflated block:
+			// if !bytes.HasSuffix(c.dst.Bytes(), []byte(deflateTrailer)) {
+			//     panic(fmt.Sprintf("Unexpected end of compressed data: %x", c.dst.Bytes()))
+			// }
 			c.dst.Truncate(c.dst.Len() - deflateTrailerLength)
 		}
 	} else {
@@ -78,6 +84,7 @@ const kDecompressorBufferSize = 8 * 1024
 
 // A 'deflate' decompression context for BLIP messages.
 type decompressor struct {
+	context   LogContext
 	checksum  hash.Hash32   // Running checksum of pre-compressed data
 	src       *bytes.Buffer // The stream compressed input is read from
 	z         io.ReadCloser // The 'deflate' decompression context
@@ -85,9 +92,10 @@ type decompressor struct {
 	outputBuf bytes.Buffer  // Temporary buffer used by ReadAll
 }
 
-func newDecompressor() *decompressor {
+func newDecompressor(context LogContext) *decompressor {
 	buffer := bytes.NewBuffer(make([]byte, 0, kBigFrameSize))
 	return &decompressor{
+		context:  context,
 		checksum: crc32.NewIEEE(),
 		src:      buffer,
 		z:        flate.NewReader(buffer),
@@ -95,7 +103,8 @@ func newDecompressor() *decompressor {
 	}
 }
 
-func (d *decompressor) reset() {
+func (d *decompressor) reset(context LogContext) {
+	d.context = context
 	d.checksum = crc32.NewIEEE()
 	d.src.Reset()
 	d.z.(flate.Resetter).Reset(d.src, nil)
@@ -131,17 +140,20 @@ func (d *decompressor) decompress(input []byte, checksum uint32) ([]byte, error)
 		// Empty input
 		return []byte{}, nil
 	}
+
+	// Restore the deflate trailer that was stripped by the compressor:
 	d.src.Write([]byte(deflateTrailer))
 
 	d.outputBuf.Reset()
-	for {
+	// Decompress until the checksum matches and there are only a few bytes of input left:
+	for d.src.Len() > deflateTrailerLength+2 || d.getChecksum() != checksum {
 		n, err := d.z.Read(d.buffer)
 		if err != nil {
-			fmt.Printf("***Decompressor error; inputLen=%d, remaining=%d, output=%d, error=%v ***\n",
+			d.context.log("ERROR decompressing frame: inputLen=%d, remaining=%d, output=%d, error=%v ***\n",
 				len(input), d.src.Len(), d.outputBuf.Len(), err)
 			return nil, err
 		} else if n == 0 {
-			// Nothing more to read; since checksum didn't match on previous loop, fail:
+			// Nothing more to read; since checksum didn't match (above), fail:
 			return nil, fmt.Errorf("Invalid checksum %x; should be %x", d.getChecksum(), checksum)
 		}
 		_, _ = d.checksum.Write(d.buffer[0:n]) // Update checksum (no error possible)
@@ -149,12 +161,6 @@ func (d *decompressor) decompress(input []byte, checksum uint32) ([]byte, error)
 		//fmt.Printf("***Decompressed %d bytes; %d remaining\n", n, d.src.Len())
 		if _, err = d.outputBuf.Write(d.buffer[:n]); err != nil {
 			return nil, err
-		}
-		// Stop if the checksum matches and there are only a few bytes of input left.
-		if remaining := d.src.Len(); remaining <= deflateTrailerLength+2 {
-			if curChecksum := d.getChecksum(); curChecksum == checksum {
-				break // Checksum matches: done!
-			}
 		}
 	}
 
@@ -189,12 +195,12 @@ func returnCompressor(c *compressor) {
 }
 
 // Gets a decompressor from the pool, or creates a new one if the pool is empty:
-func getDecompressor() *decompressor {
+func getDecompressor(context LogContext) *decompressor {
 	if d, ok := decompressorCache.Get().(*decompressor); ok {
-		d.reset()
+		d.reset(context)
 		return d
 	} else {
-		return newDecompressor()
+		return newDecompressor(context)
 	}
 }
 

--- a/codec_test.go
+++ b/codec_test.go
@@ -2,6 +2,7 @@ package blip
 
 import (
 	"bytes"
+	"fmt"
 	"math/rand"
 	"testing"
 
@@ -28,51 +29,51 @@ func init() {
 	}
 }
 
-func TestCompressDecompress(t *testing.T) {
+func TestCompressDecompressEmpty(t *testing.T) {
+	testCompressDecompress(t, []byte{})
+}
+
+func TestCompressDecompressSmallText(t *testing.T) {
 	testCompressDecompress(t, []byte("hello"))
 }
 
 func TestCompressDecompressManySizes(t *testing.T) {
-
-	// Pick two boundary value sizes to test with
-	sizesToTest := []int{1, 65535}
-
-	// And 1000 random sizes to test with
-	for i := 0; i < 1000; i++ {
-		randomSize := rando.Intn(65535)
-		if randomSize > 1 {
-			sizesToTest = append(sizesToTest, randomSize)
-		}
+	for baseSize := 0; baseSize < 65536; baseSize += 256 {
+		t.Run(fmt.Sprintf("%d-%d", baseSize, baseSize+255), func(t *testing.T) {
+			for sizeLoop := baseSize; sizeLoop < baseSize+256; sizeLoop++ {
+				size := sizeLoop // make a copy that doesn't change, to use inside the function
+				t.Run(fmt.Sprintf("%d", size), func(t *testing.T) {
+					t.Parallel()
+					testCompressDecompress(t, compressibleDataOfLength(size))
+				})
+			}
+		})
 	}
-
-	// Test compress/decompress loop with all of those sizes
-	for _, sizeToTest := range sizesToTest {
-		testCompressDecompress(t, compressibleDataOfLength(sizeToTest))
-	}
-
 }
 
 // Make sure that the decompressor returns an error with completely invalid input
 func TestDecompressInvalidInput(t *testing.T) {
-
-	decompressor := getDecompressor(TestLogContext{})
+	ctx := TestLogContext{silent: true}
+	decompressor := getDecompressor(&ctx)
 	decompressedBytes, err := decompressor.decompress([]byte("junk_input"), 2)
 	assert.True(t, err != nil)
 	assert.True(t, len(decompressedBytes) == 0)
+	assert.True(t, ctx.count > 0)
 
 }
 
 // Make sure that the decompressor returns an error with valid compressed input, but an invalid checksum
 func TestDecompressInvalidChecksum(t *testing.T) {
+	ctx := TestLogContext{silent: true}
 
 	// Compress some data
 	compressedData, checksum := testCompressData(t, []byte("uncompressed"))
 
-	decompressor := getDecompressor(TestLogContext{})
+	decompressor := getDecompressor(&ctx)
 	decompressedBytes, err := decompressor.decompress([]byte(compressedData), checksum*2)
 	assert.True(t, err != nil)
 	assert.True(t, len(decompressedBytes) == 0)
-
+	assert.True(t, ctx.count > 0)
 }
 
 func testCompressData(t *testing.T, dataToCompress []byte) (compressedData []byte, checksum uint32) {
@@ -82,8 +83,10 @@ func testCompressData(t *testing.T, dataToCompress []byte) (compressedData []byt
 	compressor := getCompressor(&compressedDest)
 	compressor.enabled = true
 	n, err := compressor.write([]byte(dataToCompress))
+	if err != nil {
+		t.Errorf("Error compressing <%x> of size %d.  Error: %v", dataToCompress, len(dataToCompress), err)
+	}
 	assert.Equals(t, n, len(dataToCompress))
-	assert.True(t, err == nil)
 	compressedData = compressedDest.Bytes()
 	checksum = compressor.getChecksum()
 	returnCompressor(compressor)
@@ -100,11 +103,11 @@ func testCompressDecompress(t *testing.T, dataToCompress []byte) {
 	//     float32(len(compressedData))/float32(len(dataToCompress)))
 
 	// Decompress it
-	decompressor := getDecompressor(TestLogContext{})
+	decompressor := getDecompressor(&TestLogContext{})
 	decompressedBytes, err := decompressor.decompress(compressedData, checksum)
 	returnDecompressor(decompressor)
 	if err != nil {
-		t.Errorf("Compression error trying to compress %s of size: %d.  Error: %v", string(dataToCompress), len(dataToCompress), err)
+		t.Errorf("Error decompressing <%x> of size %d.  Error: %v", compressedData, len(compressedData), err)
 	}
 
 	// Make sure that it decompresses to the same data

--- a/codec_test.go
+++ b/codec_test.go
@@ -55,7 +55,7 @@ func TestCompressDecompressManySizes(t *testing.T) {
 // Make sure that the decompressor returns an error with completely invalid input
 func TestDecompressInvalidInput(t *testing.T) {
 
-	decompressor := getDecompressor()
+	decompressor := getDecompressor(TestLogContext{})
 	decompressedBytes, err := decompressor.decompress([]byte("junk_input"), 2)
 	assert.True(t, err != nil)
 	assert.True(t, len(decompressedBytes) == 0)
@@ -68,7 +68,7 @@ func TestDecompressInvalidChecksum(t *testing.T) {
 	// Compress some data
 	compressedData, checksum := testCompressData(t, []byte("uncompressed"))
 
-	decompressor := getDecompressor()
+	decompressor := getDecompressor(TestLogContext{})
 	decompressedBytes, err := decompressor.decompress([]byte(compressedData), checksum*2)
 	assert.True(t, err != nil)
 	assert.True(t, len(decompressedBytes) == 0)
@@ -100,7 +100,7 @@ func testCompressDecompress(t *testing.T, dataToCompress []byte) {
 	//     float32(len(compressedData))/float32(len(dataToCompress)))
 
 	// Decompress it
-	decompressor := getDecompressor()
+	decompressor := getDecompressor(TestLogContext{})
 	decompressedBytes, err := decompressor.decompress(compressedData, checksum)
 	returnDecompressor(decompressor)
 	if err != nil {

--- a/codec_test.go
+++ b/codec_test.go
@@ -38,14 +38,14 @@ func TestCompressDecompressSmallText(t *testing.T) {
 }
 
 func TestCompressDecompressManySizes(t *testing.T) {
-	for baseSize := 0; baseSize < 65536; baseSize += 256 {
-		t.Run(fmt.Sprintf("%d-%d", baseSize, baseSize+255), func(t *testing.T) {
-			for sizeLoop := baseSize; sizeLoop < baseSize+256; sizeLoop++ {
-				size := sizeLoop // make a copy that doesn't change, to use inside the function
-				t.Run(fmt.Sprintf("%d", size), func(t *testing.T) {
-					t.Parallel()
-					testCompressDecompress(t, compressibleDataOfLength(size))
-				})
+	for s := 0; s < 65536; s += 1024 {
+		startSize := s
+		endSize := s + 1024
+		t.Run(fmt.Sprintf("%d-%d", startSize, endSize-1), func(t *testing.T) {
+			t.Parallel()
+			for size := startSize; size < endSize; size++ {
+				//t.Logf("Compressing %d bytes", size)
+				testCompressDecompress(t, compressibleDataOfLength(size))
 			}
 		})
 	}
@@ -95,7 +95,6 @@ func testCompressData(t *testing.T, dataToCompress []byte) (compressedData []byt
 }
 
 func testCompressDecompress(t *testing.T, dataToCompress []byte) {
-
 	// Compress some data
 	compressedData, checksum := testCompressData(t, dataToCompress)
 

--- a/messagequeue_test.go
+++ b/messagequeue_test.go
@@ -13,7 +13,7 @@ func TestMessagePushPop(t *testing.T) {
 
 	// Create a message queue
 	maxSendQueueCount := 5
-	mq := newMessageQueue(TestLogContext{}, maxSendQueueCount)
+	mq := newMessageQueue(&TestLogContext{silent: true}, maxSendQueueCount)
 
 	// Push a non-urgent message into the queue
 	for i := 0; i < 2; i++ {
@@ -63,7 +63,7 @@ func TestConcurrentAccess(t *testing.T) {
 
 	// Create a message queue
 	maxSendQueueCount := 5
-	mq := newMessageQueue(TestLogContext{}, maxSendQueueCount)
+	mq := newMessageQueue(&TestLogContext{silent: true}, maxSendQueueCount)
 
 	// Fill it up to capacity w/ normal messages
 	for i := 0; i < maxSendQueueCount; i++ {
@@ -136,7 +136,7 @@ func TestUrgentMessageOrdering(t *testing.T) { // Test passes, but some assertio
 
 	// Create a message queue
 	maxSendQueueCount := 25
-	mq := newMessageQueue(TestLogContext{}, maxSendQueueCount)
+	mq := newMessageQueue(&TestLogContext{silent: true}, maxSendQueueCount)
 
 	// Add normal messages that are "in-progress" since they have a non-nil msg.encoder
 	for i := 0; i < 5; i++ {
@@ -209,16 +209,28 @@ func TestUrgentMessageOrdering(t *testing.T) { // Test passes, but some assertio
 	assert.True(t, mq.length() == 0)
 }
 
-type TestLogContext struct{}
-
-func (tlc TestLogContext) log(fmt string, params ...interface{}) {
-	log.Printf(fmt, params...)
+type TestLogContext struct {
+	silent bool
+	count  int
 }
 
-func (tlc TestLogContext) logMessage(fmt string, params ...interface{}) {
-	log.Printf(fmt, params...)
+func (tlc *TestLogContext) log(fmt string, params ...interface{}) {
+	if !tlc.silent {
+		log.Printf(fmt, params...)
+	}
+	tlc.count++
 }
 
-func (tlc TestLogContext) logFrame(fmt string, params ...interface{}) {
-	log.Printf(fmt, params...)
+func (tlc *TestLogContext) logMessage(fmt string, params ...interface{}) {
+	if !tlc.silent {
+		log.Printf(fmt, params...)
+	}
+	tlc.count++
+}
+
+func (tlc *TestLogContext) logFrame(fmt string, params ...interface{}) {
+	if !tlc.silent {
+		log.Printf(fmt, params...)
+	}
+	tlc.count++
 }

--- a/receiver.go
+++ b/receiver.go
@@ -43,7 +43,7 @@ func newReceiver(context *Context, conn *websocket.Conn) *receiver {
 		conn:             conn,
 		context:          context,
 		channel:          make(chan []byte, 10),
-		frameDecoder:     getDecompressor(),
+		frameDecoder:     getDecompressor(context),
 		pendingRequests:  msgStreamerMap{},
 		pendingResponses: msgStreamerMap{},
 	}


### PR DESCRIPTION
* decompressor would fail on compressed zero-length data (a single 00
  byte.) Fixed by moving the checksum test to the top of the loop.
* Simplified the checksum test and moved into 'for' statement.
* decompressor now uses the Context to log, so client can see the
  errors.
* Added a few comments.
* Restore testing entire range of frame sizes 0..65535 with
  TestCompressDecompressManySizes (without creating a bajillion
  goroutines)
* Added silent mode and counter to TestLogContext
* Suppress error logs from TestDecompressInvalidInput and
  TestDecompressInvalidChecksum
* Suppress progress logs in messagequeue_test.go
