### PR TITLE
Fixes SG #3232 prefix unique id to go-blip logs

### DIFF
--- a/context.go
+++ b/context.go
@@ -148,7 +148,7 @@ func (context *Context) dispatchRequest(request *Message, sender *Sender) {
 		}
 	}()
 
-	context.logMessage("INCOMING REQUEST: %s", request)
+	context.logMessage("Incoming BLIP Request: %s", request)
 	handler := context.HandlerForProfile[request.Properties["Profile"]]
 	if handler == nil {
 		handler = context.DefaultHandler
@@ -168,27 +168,27 @@ func (context *Context) dispatchResponse(response *Message) {
 		}
 	}()
 
-	context.logMessage("INCOMING RESPONSE: %s", response)
+	context.logMessage("Incoming BLIP Response: %s", response)
 	//panic("UNIMPLEMENTED") //TODO
 }
 
 //////// LOGGING:
 
 func (context *Context) log(format string, params ...interface{}) {
-	formatWithContextID, paramsWithContextID := context.prependContextID(format, params...)
+	formatWithContextID, paramsWithContextID := context.PrependContextID(format, params...)
 	context.Logger(LogGeneral, formatWithContextID, paramsWithContextID...)
 }
 
 func (context *Context) logMessage(format string, params ...interface{}) {
 	if context.LogMessages {
-		formatWithContextID, paramsWithContextID := context.prependContextID(format, params...)
+		formatWithContextID, paramsWithContextID := context.PrependContextID(format, params...)
 		context.Logger(LogMessage, formatWithContextID, paramsWithContextID...)
 	}
 }
 
 func (context *Context) logFrame(format string, params ...interface{}) {
 	if context.LogFrames {
-		formatWithContextID, paramsWithContextID := context.prependContextID(format, params...)
+		formatWithContextID, paramsWithContextID := context.PrependContextID(format, params...)
 		context.Logger(LogFrame, formatWithContextID, paramsWithContextID...)
 	}
 }
@@ -204,7 +204,7 @@ func includesProtocol(header string, protocol string) bool {
 
 // Prepend a context ID to each blip logging message.  The contextID uniquely identifies the blip context, and
 // is useful for grouping the blip connections in the log output.
-func (context *Context) prependContextID(format string, params ...interface{}) (newFormat string, newParams []interface{}) {
+func (context *Context) PrependContextID(format string, params ...interface{}) (newFormat string, newParams []interface{}) {
 
 	// Add a new format placeholder for the context ID, which should appear at the beginning of the logs
 	formatWithContextID := `[%s] ` + format

--- a/context.go
+++ b/context.go
@@ -175,21 +175,18 @@ func (context *Context) dispatchResponse(response *Message) {
 //////// LOGGING:
 
 func (context *Context) log(format string, params ...interface{}) {
-	formatWithContextID, paramsWithContextID := context.PrependContextID(format, params...)
-	context.Logger(LogGeneral, formatWithContextID, paramsWithContextID...)
+	context.Logger(LogGeneral, format, params...)
 }
 
 func (context *Context) logMessage(format string, params ...interface{}) {
 	if context.LogMessages {
-		formatWithContextID, paramsWithContextID := context.PrependContextID(format, params...)
-		context.Logger(LogMessage, formatWithContextID, paramsWithContextID...)
+		context.Logger(LogMessage, format, params...)
 	}
 }
 
 func (context *Context) logFrame(format string, params ...interface{}) {
 	if context.LogFrames {
-		formatWithContextID, paramsWithContextID := context.PrependContextID(format, params...)
-		context.Logger(LogFrame, formatWithContextID, paramsWithContextID...)
+		context.Logger(LogFrame, format, params...)
 	}
 }
 
@@ -202,20 +199,6 @@ func includesProtocol(header string, protocol string) bool {
 	return false
 }
 
-// Prepend a context ID to each blip logging message.  The contextID uniquely identifies the blip context, and
-// is useful for grouping the blip connections in the log output.
-func (context *Context) PrependContextID(format string, params ...interface{}) (newFormat string, newParams []interface{}) {
-
-	// Add a new format placeholder for the context ID, which should appear at the beginning of the logs
-	formatWithContextID := `[%s] ` + format
-
-	paramsWithContextID := []interface{}{context.ID}
-	if len(params) > 0 {
-		paramsWithContextID = append(paramsWithContextID, params...)
-	}
-	return formatWithContextID, paramsWithContextID
-
-}
 
 //  Copyright (c) 2013 Jens Alfke. Copyright (c) 2015-2017 Couchbase, Inc.
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/context.go
+++ b/context.go
@@ -199,6 +199,7 @@ func includesProtocol(header string, protocol string) bool {
 	return false
 }
 
+
 //  Copyright (c) 2013 Jens Alfke. Copyright (c) 2015-2017 Couchbase, Inc.
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 //  except in compliance with the License. You may obtain a copy of the License at

--- a/context.go
+++ b/context.go
@@ -108,7 +108,7 @@ func (context *Context) WebSocketHandshake() WSHandshake {
 // Creates a WebSocket connection handler that dispatches BLIP messages to the Context.
 func (context *Context) WebSocketHandler() websocket.Handler {
 	return func(ws *websocket.Conn) {
-		context.log("Start BLIP/Websocket handler...")
+		context.log("Start BLIP/Websocket handler")
 		sender := context.start(ws)
 		err := sender.receiver.receiveLoop()
 		sender.Stop()

--- a/context.go
+++ b/context.go
@@ -3,11 +3,10 @@ package blip
 import (
 	"fmt"
 	"io"
+	"math/rand"
 	"net/http"
 	"runtime/debug"
 	"strings"
-
-	"math/rand"
 
 	"golang.org/x/net/websocket"
 )
@@ -198,7 +197,6 @@ func includesProtocol(header string, protocol string) bool {
 	}
 	return false
 }
-
 
 //  Copyright (c) 2013 Jens Alfke. Copyright (c) 2015-2017 Couchbase, Inc.
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/context.go
+++ b/context.go
@@ -52,7 +52,7 @@ func NewContext() *Context {
 	return &Context{
 		HandlerForProfile: map[string]Handler{},
 		Logger:            logPrintfWrapper(),
-		ID:                fmt.Sprintf("%x", rand.Int63()),
+		ID:                fmt.Sprintf("%x", rand.Int31()),
 	}
 }
 
@@ -198,7 +198,6 @@ func includesProtocol(header string, protocol string) bool {
 	}
 	return false
 }
-
 
 //  Copyright (c) 2013 Jens Alfke. Copyright (c) 2015-2017 Couchbase, Inc.
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/sender.go
+++ b/sender.go
@@ -110,7 +110,7 @@ func (sender *Sender) start() {
 			}
 		}()
 
-		sender.context.logFrame("Sender starting...")
+		sender.context.logFrame("Sender starting")
 		frameBuffer := bytes.NewBuffer(make([]byte, 0, kBigFrameSize))
 		frameEncoder := getCompressor(frameBuffer)
 		for {


### PR DESCRIPTION
Fixes https://github.com/couchbase/sync_gateway/issues/3232

1. Adds context id to blip context
1. Removes unnecessary "..." from a few logs
1. Lowercases a few log messages.  Eg, "INCOMING MESSAGE" -> "Incoming Message"
1. Rename `fmt` -> `format` to avoid go package name collisions