### PR TITLE
PR: BLIP client blocks indefinitely when peer abruptly closes connection

### DIFF
--- a/context.go
+++ b/context.go
@@ -85,6 +85,8 @@ func (context *Context) DialConfig(config *websocket.Config) (*Sender, error) {
 	}
 	sender := context.start(ws)
 	go func() {
+		defer decrReceiverGoroutines()
+		incrReceiverGoroutines()
 		err := sender.receiver.receiveLoop()
 		if err != nil {
 			context.log("BLIP/Websocket receiveLoop exited: %v", err)

--- a/context.go
+++ b/context.go
@@ -86,6 +86,8 @@ func (context *Context) DialConfig(config *websocket.Config) (*Sender, error) {
 	sender := context.start(ws)
 	go func() {
 		defer decrReceiverGoroutines()
+		defer sender.Stop()
+
 		incrReceiverGoroutines()
 		err := sender.receiver.receiveLoop()
 		if err != nil {

--- a/context.go
+++ b/context.go
@@ -85,10 +85,14 @@ func (context *Context) DialConfig(config *websocket.Config) (*Sender, error) {
 	}
 	sender := context.start(ws)
 	go func() {
-		defer decrReceiverGoroutines()
+
+		// If the receiveLoop terminates, stop the sender as well
 		defer sender.Stop()
 
+		// Update Expvar stats for number of outstanding goroutines
 		incrReceiverGoroutines()
+		defer decrReceiverGoroutines()
+
 		err := sender.receiver.receiveLoop()
 		if err != nil {
 			context.log("BLIP/Websocket receiveLoop exited: %v", err)

--- a/context_test.go
+++ b/context_test.go
@@ -261,7 +261,7 @@ func TestClientAbruptlyCloseConnectionBehavior(t *testing.T) {
 	receivedEchoRequest.Wait()
 
 	// Read the echo response
-	response := echoRequest.Response()   // <-- blocks indefinitely here.
+	response := echoRequest.Response()   
 	responseBody, err := response.Body()
 
 	// Assertions about echo response (these might need to be altered, maybe what's expected in this scenario is actually an error)

--- a/context_test.go
+++ b/context_test.go
@@ -174,12 +174,12 @@ func TestClientAbruptlyCloseConnectionBehavior(t *testing.T) {
 		echoAmplifyRequest.SetBody([]byte("hello"))
 		sent := clientSender.Send(echoAmplifyRequest)
 		assert.True(t, sent)
-		echoAmplifyResponse := echoAmplifyRequest.Response()  // <--- blocks indefinitely
-		_, err := echoAmplifyResponse.Body()
+		echoAmplifyResponse := echoAmplifyRequest.Response()  // <--- SG #3268 was causing this to block indefinitely
+		echoAmplifyResponseBody, _ := echoAmplifyResponse.Body()
+		assert.True(t, len(echoAmplifyResponseBody) == 0)
 
-		// since the test will end abruptly close socket before sending a response, the expected behavior
-		// is return an error (as opposed to calling Body() blocking forever)
-		assert.True(t, err != nil)
+		// TODO: add more assertions about the response.  I'm not seeing any errors, or any
+		// TODO: way to differentiate this response with a normal response other than having an empty body
 
 	}
 
@@ -261,7 +261,7 @@ func TestClientAbruptlyCloseConnectionBehavior(t *testing.T) {
 	receivedEchoRequest.Wait()
 
 	// Read the echo response
-	response := echoRequest.Response()   
+	response := echoRequest.Response()
 	responseBody, err := response.Body()
 
 	// Assertions about echo response (these might need to be altered, maybe what's expected in this scenario is actually an error)

--- a/context_test.go
+++ b/context_test.go
@@ -3,6 +3,7 @@ package blip
 import (
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"sync"
 	"testing"
@@ -73,14 +74,20 @@ func TestServerAbruptlyCloseConnectionBehavior(t *testing.T) {
 
 	// HTTP Handler wrapping websocket server
 	http.Handle("/blip", defaultHandler)
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		panic(err)
+	}
 	go func() {
-		log.Fatal(http.ListenAndServe(":12345", nil)) // TODO: use dynamic port
+		panic(http.Serve(listener, nil))
 	}()
 
 	// ----------------- Setup Echo Client ----------------------------------------
 
 	blipContextEchoClient := NewContext()
-	sender, err := blipContextEchoClient.Dial("ws://localhost:12345/blip", "http://localhost")
+	port := listener.Addr().(*net.TCPAddr).Port
+	destUrl := fmt.Sprintf("ws://localhost:%d/blip", port)
+	sender, err := blipContextEchoClient.Dial(destUrl, "http://localhost")
 	if err != nil {
 		panic("Error opening WebSocket: " + err.Error())
 	}
@@ -224,14 +231,20 @@ func TestClientAbruptlyCloseConnectionBehavior(t *testing.T) {
 
 	// HTTP Handler wrapping websocket server
 	http.Handle("/blip", defaultHandler)
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		panic(err)
+	}
 	go func() {
-		log.Fatal(http.ListenAndServe(":12345", nil)) // TODO: use dynamic port
+		panic(http.Serve(listener, nil))
 	}()
 
 	// ----------------- Setup Echo Client ----------------------------------------
 
 	blipContextEchoClient := NewContext()
-	sender, err := blipContextEchoClient.Dial("ws://localhost:12345/blip", "http://localhost")
+	port := listener.Addr().(*net.TCPAddr).Port
+	destUrl := fmt.Sprintf("ws://localhost:%d/blip", port)
+	sender, err := blipContextEchoClient.Dial(destUrl, "http://localhost")
 	if err != nil {
 		panic("Error opening WebSocket: " + err.Error())
 	}

--- a/context_test.go
+++ b/context_test.go
@@ -73,7 +73,7 @@ func TestServerAbruptlyCloseConnectionBehavior(t *testing.T) {
 	}
 
 	// HTTP Handler wrapping websocket server
-	http.Handle("/blip", defaultHandler)
+	http.Handle("/TestServerAbruptlyCloseConnectionBehavior", defaultHandler)
 	listener, err := net.Listen("tcp", ":0")
 	if err != nil {
 		panic(err)
@@ -86,7 +86,7 @@ func TestServerAbruptlyCloseConnectionBehavior(t *testing.T) {
 
 	blipContextEchoClient := NewContext()
 	port := listener.Addr().(*net.TCPAddr).Port
-	destUrl := fmt.Sprintf("ws://localhost:%d/blip", port)
+	destUrl := fmt.Sprintf("ws://localhost:%d/TestServerAbruptlyCloseConnectionBehavior", port)
 	sender, err := blipContextEchoClient.Dial(destUrl, "http://localhost")
 	if err != nil {
 		panic("Error opening WebSocket: " + err.Error())
@@ -230,7 +230,7 @@ func TestClientAbruptlyCloseConnectionBehavior(t *testing.T) {
 	}
 
 	// HTTP Handler wrapping websocket server
-	http.Handle("/blip", defaultHandler)
+	http.Handle("/TestClientAbruptlyCloseConnectionBehavior", defaultHandler)
 	listener, err := net.Listen("tcp", ":0")
 	if err != nil {
 		panic(err)
@@ -243,7 +243,7 @@ func TestClientAbruptlyCloseConnectionBehavior(t *testing.T) {
 
 	blipContextEchoClient := NewContext()
 	port := listener.Addr().(*net.TCPAddr).Port
-	destUrl := fmt.Sprintf("ws://localhost:%d/blip", port)
+	destUrl := fmt.Sprintf("ws://localhost:%d/TestClientAbruptlyCloseConnectionBehavior", port)
 	sender, err := blipContextEchoClient.Dial(destUrl, "http://localhost")
 	if err != nil {
 		panic("Error opening WebSocket: " + err.Error())

--- a/context_test.go
+++ b/context_test.go
@@ -99,12 +99,15 @@ func TestServerAbruptlyCloseConnectionBehavior(t *testing.T) {
 	receivedRequests.Wait()
 
 	// Read the echo response
-	response := echoRequest.Response()   // <-- blocks indefinitely here.
+	response := echoRequest.Response()   // <--- SG #3268 was causing this to block indefinitely
 	responseBody, err := response.Body()
 
 	// Assertions about echo response (these might need to be altered, maybe what's expected in this scenario is actually an error)
 	assert.True(t, err == nil)
-	assert.Equals(t, responseBody, []byte("hello"))
+	assert.True(t, len(responseBody) == 0)
+
+	// TODO: add more assertions about the response.  I'm not seeing any errors, or any
+	// TODO: way to differentiate this response with a normal response other than having an empty body
 
 }
 

--- a/context_test.go
+++ b/context_test.go
@@ -118,8 +118,10 @@ to be answered is:
 - If the client side abruptly closes a connection during a pending server request that requires a response,
 will the server side goroutine trying to read the response be blocked indefinitely?
 
-The test does the following steps.  After writing the initial test, I've realized that the initial
-Echo Request and Echo Response are probably unnecessary, but I'm leaving them in for now.
+The initial Echo Request and Echo Response might be unnecessary -- it was used to provide a way for the server
+to issue an outbound request to a client.  Is there a simpler way?
+
+The test does the following steps:
 
 
 ┌─────────────────────────────┐                                  ┌─────────────────────────────┐

--- a/context_test.go
+++ b/context_test.go
@@ -15,7 +15,7 @@ import (
 // confirm or deny erroneous behavior w.r.t sockets being abruptly closed.  The main question attempted
 // to be answered is:
 //
-// - If one side abruptly closes a connection, will the other side receive an error or be "stuck" indefinitely
+// - If server side abruptly closes a connection, will the client side receive an error or be "stuck" indefinitely
 //
 // Test:
 //
@@ -26,7 +26,7 @@ import (
 // - Expected: the echo client should receive some sort of error when trying to read the response, since the server abruptly terminated the connection
 // - Actual: the echo client blocks indefinitely trying to read the response
 //
-func TestAbruptlyCloseConnectionBehavior(t *testing.T) {
+func TestServerAbruptlyCloseConnectionBehavior(t *testing.T) {
 
 	blipContextEchoServer := NewContext()
 
@@ -73,7 +73,7 @@ func TestAbruptlyCloseConnectionBehavior(t *testing.T) {
 	// HTTP Handler wrapping websocket server
 	http.Handle("/blip", defaultHandler)
 	go func() {
-		log.Fatal(http.ListenAndServe(":12345", nil))
+		log.Fatal(http.ListenAndServe(":12345", nil))  // TODO: use dynamic port
 	}()
 
 	// ----------------- Setup Echo Client ----------------------------------------
@@ -105,5 +105,172 @@ func TestAbruptlyCloseConnectionBehavior(t *testing.T) {
 	// Assertions about echo response (these might need to be altered, maybe what's expected in this scenario is actually an error)
 	assert.True(t, err == nil)
 	assert.Equals(t, responseBody, []byte("hello"))
+
+}
+
+
+/*
+
+This was added in reaction to https://github.com/couchbase/sync_gateway/issues/3268 to either
+confirm or deny erroneous behavior w.r.t sockets being abruptly closed.  The main question attempted
+to be answered is:
+
+- If the client side abruptly closes a connection during a pending server request that requires a response,
+will the server side goroutine trying to read the response be blocked indefinitely?
+
+The test does the following steps.  After writing the initial test, I've realized that the initial
+Echo Request and Echo Response are probably unnecessary, but I'm leaving them in for now.
+
+
+┌─────────────────────────────┐                                  ┌─────────────────────────────┐
+│    blipContextEchoClient    │                                  │    blipContextEchoServer    │
+└──────────────┬──────────────┘                                  └──────────────┬──────────────┘
+               │                                                                │
+               ├──────────────────────────────Dial──────────────────────────────▶
+               │                                                                │
+               │                               Echo                             │
+               ├─────────────────────────────Request────────────────────────────▶
+               │                                                                │
+               │                              Echo                              │
+               ◀────────────────────────────Response────────────────────────────┤
+               │                                                                │
+               │                               Echo                             │
+               ◀─────────────────────────────Amplify ───────────────────────────┤
+               │                             Request                            │
+               │                                                                │
+               │                              Close                             │
+               ├────────────────────────────Connection──────────────────────────▶
+               │                                                                │
+               │                                                                │
+               │                        Echo Response Never                     │
+               ├ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─Happens─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─▶
+               │                          Shouldn't Block                       │
+               │                                                                │
+               │                                                                │
+               │                                                                │
+               ▼                                                                ▼
+
+ */
+func TestClientAbruptlyCloseConnectionBehavior(t *testing.T) {
+
+	blipContextEchoServer := NewContext()
+
+	receivedEchoRequest := sync.WaitGroup{}
+	echoAmplifyRoundTripComplete := sync.WaitGroup{}
+
+	// ----------------- Setup Echo Server that abruptly terminates socket -------------------------
+
+	// This "amplifies" the echo by sending an additional outbound request to the client
+	// in response to the originally received echo
+	sendEchoAmplify := func(clientSender *Sender) {
+
+		defer echoAmplifyRoundTripComplete.Done()
+
+		echoAmplifyRequest := NewRequest()
+		echoAmplifyRequest.SetProfile("BLIPTest/EchoAmplifyData")
+		echoAmplifyRequest.Properties["Content-Type"] = "application/octet-stream"
+		echoAmplifyRequest.SetBody([]byte("hello"))
+		sent := clientSender.Send(echoAmplifyRequest)
+		assert.True(t, sent)
+		echoAmplifyResponse := echoAmplifyRequest.Response()
+		echoAmplifyResponseBody, err := echoAmplifyResponse.Body()
+
+		log.Printf("echoAmplifyResponse.Body() err: %+v", err)
+		log.Printf("echoAmplifyResponse.Body(): %s", echoAmplifyResponseBody)
+
+
+		// since the test will end abruptly close socket before sending a response, the expected behavior
+		// is return an error (as opposed to calling Body() blocking forever)
+		// assert.True(t, err != nil)
+
+	}
+
+	// Create a blip profile handler to respond to echo requests and then abruptly close the socket
+	dispatchEcho := func(request *Message) {
+		defer receivedEchoRequest.Done()
+		body, err := request.Body()
+		if err != nil {
+			log.Printf("ERROR reading body of %s: %s", request, err)
+			return
+		}
+		if request.Properties["Content-Type"] != "application/octet-stream" {
+			panic(fmt.Sprintf("Incorrect properties: %#x", request.Properties))
+		}
+		if response := request.Response(); response != nil {
+			response.SetBody(body)
+			response.Properties["Content-Type"] = request.Properties["Content-Type"]
+		}
+
+		echoAmplifyRoundTripComplete.Add(1)
+		go sendEchoAmplify(request.Sender)
+
+	}
+
+	// Blip setup
+	blipContextEchoServer.HandlerForProfile["BLIPTest/EchoData"] = dispatchEcho
+	blipContextEchoServer.LogMessages = true
+	blipContextEchoServer.LogFrames = true
+
+	// Websocket Server
+	server := blipContextEchoServer.WebSocketServer()
+	defaultHandler := server.Handler
+	server.Handler = func(conn *websocket.Conn) {
+		defer func() {
+			conn.Close() // in case it wasn't closed already
+		}()
+		defaultHandler(conn)
+	}
+
+	// HTTP Handler wrapping websocket server
+	http.Handle("/blip", defaultHandler)
+	go func() {
+		log.Fatal(http.ListenAndServe(":12345", nil))  // TODO: use dynamic port
+	}()
+
+	// ----------------- Setup Echo Client ----------------------------------------
+
+	blipContextEchoClient := NewContext()
+	sender, err := blipContextEchoClient.Dial("ws://localhost:12345/blip", "http://localhost")
+	if err != nil {
+		panic("Error opening WebSocket: " + err.Error())
+	}
+
+	// Handle EchoAmplifyData that should be initiated by server in response to getting incoming echo requests
+	dispatchEchoAmplify := func(request *Message) {
+		_, err := request.Body()
+		if err != nil {
+			log.Printf("ERROR reading body of %s: %s", request, err)
+			return
+		}
+		// Abruptly close the websocket connection before sending a response
+		request.Sender.Close()
+
+	}
+	blipContextEchoClient.HandlerForProfile["BLIPTest/EchoAmplifyData"] = dispatchEchoAmplify
+
+	// Create echo request
+	echoRequest := NewRequest()
+	echoRequest.SetProfile("BLIPTest/EchoData")
+	echoRequest.Properties["Content-Type"] = "application/octet-stream"
+	echoRequest.SetBody([]byte("hello"))
+	receivedEchoRequest.Add(1)
+
+	// Send echo request
+	sent := sender.Send(echoRequest)
+	assert.True(t, sent)
+
+	// Wait until the echo server profile handler was invoked and completely finished (and thus abruptly closed socket)
+	receivedEchoRequest.Wait()
+
+	// Read the echo response
+	response := echoRequest.Response()   // <-- blocks indefinitely here.
+	responseBody, err := response.Body()
+
+	// Assertions about echo response (these might need to be altered, maybe what's expected in this scenario is actually an error)
+	assert.True(t, err == nil)
+	assert.Equals(t, string(responseBody), "hello")
+
+	// Wait until the amplify request was received by client (from server), and that the server read the response
+	echoAmplifyRoundTripComplete.Wait()
 
 }

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,120 @@
+package blip
+
+import (
+	"testing"
+	"log"
+	"fmt"
+	"golang.org/x/net/websocket"
+	"net/http"
+	"math/rand"
+	"github.com/couchbaselabs/go.assert"
+	"sync"
+)
+
+// This was added in reaction to https://github.com/couchbase/sync_gateway/issues/3268 to either
+// confirm or deny erroneous behavior w.r.t sockets being abruptly closed.  The main question attempted
+// to be answered is:
+//
+// - If one side abruptly closes a connection, will the other side receive an error or be "stuck" indefinitely
+//
+// Test:
+//
+// - Start two blip contexts
+// - Start ping-pong message between them
+// - One side abruptly closes connection
+// - Verify the other side is not stuck indefinitely
+//
+func TestAbruptlyCloseConnectionBehavior(t *testing.T) {
+
+	blipContext := NewContext()
+
+	receivedRequests := sync.WaitGroup{}
+
+	dispatchEcho := func(request *Message) {
+		defer receivedRequests.Done()
+		body, err := request.Body()
+		if err != nil {
+			log.Printf("ERROR reading body of %s: %s", request, err)
+			return
+		}
+		for i, b := range body {
+			if b != byte(i%256) {
+				panic(fmt.Sprintf("Incorrect body: %x", body))
+			}
+		}
+		if request.Properties["Content-Type"] != "application/octet-stream" {
+			panic(fmt.Sprintf("Incorrect properties: %#x", request.Properties))
+		}
+		if response := request.Response(); response != nil {
+			response.SetBody(body)
+			response.Properties["Content-Type"] = request.Properties["Content-Type"]
+		}
+	}
+
+
+	blipContext.HandlerForProfile["BLIPTest/EchoData"] = dispatchEcho
+	blipContext.LogMessages = true
+	blipContext.LogFrames = true
+
+
+	// Server
+	server := blipContext.WebSocketServer()
+	defaultHandler := server.Handler
+	server.Handler = func(conn *websocket.Conn) {
+		defer func() {
+			conn.Close() // in case it wasn't closed already
+		}()
+		defaultHandler(conn)
+	}
+
+	http.Handle("/blip", defaultHandler)
+
+	go func() {
+		log.Fatal(http.ListenAndServe(":12345", nil))
+	}()
+
+	context := NewContext()
+	sender, err := context.Dial("ws://localhost:12345/blip", "http://localhost")
+	if err != nil {
+		panic("Error opening WebSocket: " + err.Error())
+	}
+
+	request := NewRequest()
+	request.SetProfile("BLIPTest/EchoData")
+	request.Properties["Content-Type"] = "application/octet-stream"
+	body := make([]byte, rand.Intn(1024))
+	for i := 0; i < len(body); i++ {
+		body[i] = byte(i % 256)
+	}
+	request.SetBody(body)
+	receivedRequests.Add(1)
+	sent := sender.Send(request)
+	assert.True(t, sent)
+
+	log.Printf("sent request")
+
+	receivedRequests.Wait()
+
+
+}
+
+
+//func dispatchEcho(request *Message) {
+//	body, err := request.Body()
+//	if err != nil {
+//		log.Printf("ERROR reading body of %s: %s", request, err)
+//		return
+//	}
+//	for i, b := range body {
+//		if b != byte(i%256) {
+//			panic(fmt.Sprintf("Incorrect body: %x", body))
+//		}
+//	}
+//	if request.Properties["Content-Type"] != "application/octet-stream" {
+//		panic(fmt.Sprintf("Incorrect properties: %#x", request.Properties))
+//	}
+//	if response := request.Response(); response != nil {
+//		response.SetBody(body)
+//		response.Properties["Content-Type"] = request.Properties["Content-Type"]
+//	}
+//}

--- a/context_test.go
+++ b/context_test.go
@@ -174,16 +174,12 @@ func TestClientAbruptlyCloseConnectionBehavior(t *testing.T) {
 		echoAmplifyRequest.SetBody([]byte("hello"))
 		sent := clientSender.Send(echoAmplifyRequest)
 		assert.True(t, sent)
-		echoAmplifyResponse := echoAmplifyRequest.Response()
-		echoAmplifyResponseBody, err := echoAmplifyResponse.Body()
-
-		log.Printf("echoAmplifyResponse.Body() err: %+v", err)
-		log.Printf("echoAmplifyResponse.Body(): %s", echoAmplifyResponseBody)
-
+		echoAmplifyResponse := echoAmplifyRequest.Response()  // <--- blocks indefinitely
+		_, err := echoAmplifyResponse.Body()
 
 		// since the test will end abruptly close socket before sending a response, the expected behavior
 		// is return an error (as opposed to calling Body() blocking forever)
-		// assert.True(t, err != nil)
+		assert.True(t, err != nil)
 
 	}
 

--- a/expvar.go
+++ b/expvar.go
@@ -1,0 +1,48 @@
+package blip
+
+import "expvar"
+
+// Expvar instrumentation
+var (
+	numGoroutines = expvar.NewMap("goblip")
+)
+
+func incrReceiverGoroutines() {
+	numGoroutines.Add("goroutines_receiver", 1)
+}
+
+func decrReceiverGoroutines() {
+	numGoroutines.Add("goroutines_receiver", -1)
+}
+
+func incrAsyncReadGoroutines() {
+	numGoroutines.Add("goroutines_async_read", 1)
+}
+
+func decrAsyncReadGoroutines() {
+	numGoroutines.Add("goroutines_async_read", -1)
+}
+
+func incrNextFrameToSendGoroutines() {
+	numGoroutines.Add("goroutines_next_frame_to_send", 1)
+}
+
+func decrNextFrameToSendGoroutines() {
+	numGoroutines.Add("goroutines_next_frame_to_send", -1)
+}
+
+func incrParseLoopGoroutines() {
+	numGoroutines.Add("goroutines_parse_loop", 1)
+}
+
+func decrParseLoopGoroutines() {
+	numGoroutines.Add("goroutines_parse_loop", -1)
+}
+
+func incrSenderGoroutines() {
+	numGoroutines.Add("goroutines_sender", 1)
+}
+
+func decrSenderGoroutines() {
+	numGoroutines.Add("goroutines_sender", -1)
+}

--- a/message.go
+++ b/message.go
@@ -25,13 +25,13 @@ type Message struct {
 	bytesSent  uint64
 	bytesAcked uint64
 
-	reader       io.Reader  // Stream that an incoming message is being read from
-	encoder      io.Reader  // Stream that an outgoing message is being written to
-	readingBody  bool       // True if reader stream has been accessed by client already
-	complete     bool       // Has this message been completely received?
-	response     *Message   // Response to this message, if it's a request
-	inResponseTo *Message   // Message this is a response to
-	cond         *sync.Cond // Used to make Response() method block until response arrives
+	reader       io.ReadCloser // Stream that an incoming message is being read from
+	encoder      io.Reader     // Stream that an outgoing message is being written to
+	readingBody  bool          // True if reader stream has been accessed by client already
+	complete     bool          // Has this message been completely received?
+	response     *Message      // Response to this message, if it's a request
+	inResponseTo *Message      // Message this is a response to
+	cond         *sync.Cond    // Used to make Response() method block until response arrives
 }
 
 // Returns a string describing the message for debugging purposes
@@ -249,7 +249,7 @@ func (response *Message) SetError(errDomain string, errCode int, message string)
 
 //////// INTERNALS:
 
-func newIncomingMessage(sender *Sender, number MessageNumber, flags frameFlags, reader io.Reader) *Message {
+func newIncomingMessage(sender *Sender, number MessageNumber, flags frameFlags, reader io.ReadCloser) *Message {
 	return &Message{
 		Sender: sender,
 		flags:  flags | kMoreComing,

--- a/message.go
+++ b/message.go
@@ -311,6 +311,8 @@ func (m *Message) WriteTo(writer io.Writer) error {
 }
 
 func (m *Message) ReadFrom(reader io.Reader) error {
+
+	// TODO: this call can block forever
 	if err := m.Properties.ReadFrom(reader); err != nil {
 		return err
 	}
@@ -322,6 +324,11 @@ func (m *Message) ReadFrom(reader io.Reader) error {
 // Returns a write stream to write the incoming message's content into. When the stream is closed,
 // the message will deliver itself.
 func (m *Message) asyncRead(onComplete func(error)) io.WriteCloser {
+
+	// TODO: this can block forever at the m.ReadFrom() call.
+	// Possible fix: if the websocket is detected to be closed, and the pipe reader (or writer?  or both?) was
+	// closed in reaction to that, then maybe the m.ReadFrom() call would return an error
+
 	reader, writer := io.Pipe()
 	m.reader = reader
 	go func() {

--- a/messagequeue.go
+++ b/messagequeue.go
@@ -144,8 +144,13 @@ func (q *messageQueue) stop() {
 	q.cond.L.Lock()
 	defer q.cond.L.Unlock()
 
+	// TODO: iterate over messages and call close on every message's reader
+	// TODO: each message needs to be a readcloser
+
 	q.queue = nil
 	q.cond.Broadcast()
+
+
 }
 
 func (q *messageQueue) nextMessageIsUrgent() bool {

--- a/messagequeue.go
+++ b/messagequeue.go
@@ -145,8 +145,9 @@ func (q *messageQueue) stop() {
 	defer q.cond.L.Unlock()
 
 
-	// Iterate over messages and call close on every message's readcloser, otherwise
-	// anything blocked in a Read() call on this reader will block indefinitely (SG #3268)
+	// Iterate over messages and call close on every message's readcloser, since it's possible that
+	// a goroutine may be blocked on the reader, thus causing a resource leak.  Added during SG #3268
+	// diagnosis, but does not fix any reproducible issues.
 	for _, message := range q.queue {
 		err := message.reader.Close()
 		if err != nil {

--- a/receiver.go
+++ b/receiver.go
@@ -73,7 +73,6 @@ func (r *receiver) receiveLoop() error {
 }
 
 func (r *receiver) parseLoop() {
-	defer decrParseLoopGoroutines()
 	defer func() { // Panic handler:
 		if p := recover(); p != nil {
 			log.Printf("PANIC in BLIP parseLoop: %v\n%s", p, debug.Stack())
@@ -85,7 +84,9 @@ func (r *receiver) parseLoop() {
 		}
 	}()
 
+	// Update Expvar stats for number of outstanding goroutines
 	incrParseLoopGoroutines()
+	defer decrParseLoopGoroutines()
 
 	for frame := range r.channel {
 		if r.parseError == nil {

--- a/receiver.go
+++ b/receiver.go
@@ -244,8 +244,10 @@ func (r *receiver) getPendingResponse(requestNumber MessageNumber, flags frameFl
 			delete(r.pendingResponses, requestNumber)
 		}
 	} else if requestNumber <= r.maxPendingResponseNumber {
+		// sent a request that wasn't expecting a response for?
 		r.context.log("Warning: Unexpected response frame to my msg #%d", requestNumber) // benign
 	} else {
+		// processing a response frame with a message number higher than any requests I've sent
 		err = fmt.Errorf("Bogus message number %d in response.  Expected to be less than max pending response number (%d)", requestNumber, r.maxPendingResponseNumber)
 	}
 	return

--- a/receiver.go
+++ b/receiver.go
@@ -73,8 +73,8 @@ func (r *receiver) receiveLoop() error {
 }
 
 func (r *receiver) parseLoop() {
-	// Panic handler:
-	defer func() {
+	defer decrParseLoopGoroutines()
+	defer func() { // Panic handler:
 		if p := recover(); p != nil {
 			log.Printf("PANIC in BLIP parseLoop: %v\n%s", p, debug.Stack())
 			err, _ := p.(error)
@@ -85,6 +85,8 @@ func (r *receiver) parseLoop() {
 		}
 	}()
 
+	incrParseLoopGoroutines()
+	
 	for frame := range r.channel {
 		if r.parseError == nil {
 			if err := r.handleIncomingFrame(frame); err != nil {

--- a/receiver.go
+++ b/receiver.go
@@ -86,7 +86,7 @@ func (r *receiver) parseLoop() {
 	}()
 
 	incrParseLoopGoroutines()
-	
+
 	for frame := range r.channel {
 		if r.parseError == nil {
 			if err := r.handleIncomingFrame(frame); err != nil {

--- a/sender.go
+++ b/sender.go
@@ -121,9 +121,10 @@ func (sender *Sender) start() {
 				log.Printf("PANIC in BLIP sender: %v\n%s", panicked, debug.Stack())
 			}
 		}()
-		defer decrSenderGoroutines()
 
+		// Update Expvar stats for number of outstanding goroutines
 		incrSenderGoroutines()
+		defer decrSenderGoroutines()
 
 		sender.context.logFrame("Sender starting")
 		frameBuffer := bytes.NewBuffer(make([]byte, 0, kBigFrameSize))

--- a/sender.go
+++ b/sender.go
@@ -113,6 +113,8 @@ func (sender *Sender) start() {
 				log.Printf("PANIC in BLIP sender: %v\n%s", panicked, debug.Stack())
 			}
 		}()
+		incrSenderGoroutines()
+		defer decrSenderGoroutines()
 
 		sender.context.logFrame("Sender starting")
 		frameBuffer := bytes.NewBuffer(make([]byte, 0, kBigFrameSize))

--- a/sender.go
+++ b/sender.go
@@ -99,18 +99,11 @@ func (sender *Sender) Backlog() (incomingRequests, incomingResponses, outgoingRe
 // Stops the sender's goroutine.
 func (sender *Sender) Stop() {
 	sender.queue.stop()
-
-	// There can be goroutines spawned by message.asyncRead() that are blocked waiting to
-	// read off their end of an io.Pipe, and if the peer abruptly closes a connection which causes
-	// the sender to stop(), the other side of that io.Pipe must be closed to avoid the goroutine's
-	// call to unblock on the read() call.  This loops through any io.Pipewriters in pendingResponses and
-	// close them, unblocking the readers and letting the message.asyncRead() goroutines proceed.
-	for _, msgStreamer := range sender.receiver.pendingResponses {
-		err := msgStreamer.writer.Close()
-		if err != nil {
-			sender.context.logMessage("Warning: error closing msgStreamer writer in pending responses while stopping sender: %v", err)
-		}
+	if sender.receiver != nil {
+		sender.receiver.stop()
 	}
+
+
 
 }
 

--- a/sender.go
+++ b/sender.go
@@ -128,8 +128,9 @@ func (sender *Sender) start() {
 				log.Printf("PANIC in BLIP sender: %v\n%s", panicked, debug.Stack())
 			}
 		}()
-		incrSenderGoroutines()
 		defer decrSenderGoroutines()
+
+		incrSenderGoroutines()
 
 		sender.context.logFrame("Sender starting")
 		frameBuffer := bytes.NewBuffer(make([]byte, 0, kBigFrameSize))


### PR DESCRIPTION
Fixes https://github.com/couchbase/go-blip/issues/17
Fixes https://github.com/couchbase/sync_gateway/issues/3268

Changes:

- Add go-blip tests to detect issues originally seen in https://github.com/couchbase/sync_gateway/issues/3268.  
- Add expvars to instrument go-blip related goroutines, to help identify resource leaks
- Fix underlying issue that caused tests added in this PR to block indefinitely -- in `sender.stop()`, see the code added `for _, msgStreamer := range sender.receiver.pendingResponses {...}`