### PR TITLE
Feature/sg issue 3221 bogus msg cleanup

### DIFF
--- a/context.go
+++ b/context.go
@@ -48,10 +48,14 @@ type LogContext interface {
 
 // Creates a new Context with an empty dispatch table.
 func NewContext() *Context {
+	return NewContextCustomID(fmt.Sprintf("%x", rand.Int31()))
+}
+
+func NewContextCustomID(id string) *Context {
 	return &Context{
 		HandlerForProfile: map[string]Handler{},
 		Logger:            logPrintfWrapper(),
-		ID:                fmt.Sprintf("%x", rand.Int31()),
+		ID:                id,
 	}
 }
 

--- a/functional_test.go
+++ b/functional_test.go
@@ -1,0 +1,107 @@
+package blip
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/couchbaselabs/go.assert"
+	"golang.org/x/net/websocket"
+)
+
+// Round trip a high number of messages over a loopback websocket
+// It was originally an attempt to repro SG issue https://github.com/couchbase/sync_gateway/issues/3221 isolated
+// to go-blip.  This test was not able to repro that particular error, but is useful in it's own right as a
+// regression test or starting point for other test cases that require two peers running over an actual websocket,
+// aka a "functional test".
+func TestEchoRoundTrip(t *testing.T) {
+
+	blipContextEchoServer := NewContext()
+
+	receivedRequests := sync.WaitGroup{}
+
+	// ----------------- Setup Echo Server  -------------------------
+
+	// Create a blip profile handler to respond to echo requests and then abruptly close the socket
+	dispatchEcho := func(request *Message) {
+		defer receivedRequests.Done()
+		body, err := request.Body()
+		if err != nil {
+			log.Printf("ERROR reading body of %s: %s", request, err)
+			return
+		}
+		if request.Properties["Content-Type"] != "application/octet-stream" {
+			panic(fmt.Sprintf("Incorrect properties: %#x", request.Properties))
+		}
+		if response := request.Response(); response != nil {
+			response.SetBody(body)
+			response.Properties["Content-Type"] = request.Properties["Content-Type"]
+		}
+
+	}
+
+	// Blip setup
+	blipContextEchoServer.HandlerForProfile["BLIPTest/EchoData"] = dispatchEcho
+	blipContextEchoServer.LogMessages = false
+	blipContextEchoServer.LogFrames = false
+
+	// Websocket Server
+	server := blipContextEchoServer.WebSocketServer()
+	defaultHandler := server.Handler
+	server.Handler = func(conn *websocket.Conn) {
+		defer func() {
+			conn.Close() // in case it wasn't closed already
+		}()
+		defaultHandler(conn)
+	}
+
+	// HTTP Handler wrapping websocket server
+	http.Handle("/blip", defaultHandler)
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		panic(err)
+	}
+	go func() {
+		panic(http.Serve(listener, nil))
+	}()
+
+	// ----------------- Setup Echo Client ----------------------------------------
+
+	blipContextEchoClient := NewContext()
+	port := listener.Addr().(*net.TCPAddr).Port
+	destUrl := fmt.Sprintf("ws://localhost:%d/blip", port)
+	sender, err := blipContextEchoClient.Dial(destUrl, "http://localhost")
+	if err != nil {
+		panic("Error opening WebSocket: " + err.Error())
+	}
+
+	numRequests := 50000
+	receivedRequests.Add(numRequests)
+
+	for i := 0; i < numRequests; i++ {
+
+		// Create echo request
+		echoRequest := NewRequest()
+		echoRequest.SetProfile("BLIPTest/EchoData")
+		echoRequest.Properties["Content-Type"] = "application/octet-stream"
+		echoRequest.SetBody([]byte("hello"))
+
+		// Send echo request
+		sent := sender.Send(echoRequest)
+		assert.True(t, sent)
+
+		// Read the echo response
+		response := echoRequest.Response()
+		responseBody, err := response.Body()
+		assert.True(t, err == nil)
+		assert.Equals(t, string(responseBody), "hello")
+
+	}
+
+	// Wait until all requests were sent and responded to
+	receivedRequests.Wait()
+
+}

--- a/message.go
+++ b/message.go
@@ -357,6 +357,9 @@ func (m *Message) nextFrameToSend(maxSize int) ([]byte, frameFlags) {
 	return frame, flags
 }
 
+// A callback function that takes a message and returns nothing
+type MessageCallback func(*Message)
+
 //  Copyright (c) 2013 Jens Alfke. Copyright (c) 2015-2017 Couchbase, Inc.
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 //  except in compliance with the License. You may obtain a copy of the License at

--- a/sender.go
+++ b/sender.go
@@ -84,11 +84,7 @@ func (sender *Sender) send(msg *Message) bool {
 		}
 	}
 
-	if !sender.queue.pushWithCallback(msg, prePushCallback) {
-		return false
-	}
-
-	return true
+	return sender.queue.pushWithCallback(msg, prePushCallback)
 }
 
 // Returns statistics about the number of incoming and outgoing messages queued.

--- a/sender.go
+++ b/sender.go
@@ -69,17 +69,25 @@ func (sender *Sender) send(msg *Message) bool {
 	}
 	msg.Sender = sender
 
-	if !sender.queue.push(msg) {
+	// This callback function will be called by queue.pushWithCallback() after the
+	// message is assigned a number, but *before* it is put in the send queue.
+	// It will create the io.Pipe and store the io.PipeWriter into the pendingResponses map
+	// before the message is ever queued, preventing any possible races where the message is
+	// sent and a reply is received before anything added to pendingResponses (SG issue #3221)
+	prePushCallback := func(prePushMsg *Message) {
+		if prePushMsg.Type() == RequestType && !prePushMsg.NoReply() {
+			response := prePushMsg.createResponse()
+			writer := response.asyncRead(func(err error) {
+				prePushMsg.responseComplete(response)
+			})
+			sender.receiver.awaitResponse(response, writer)
+		}
+	}
+
+	if !sender.queue.pushWithCallback(msg, prePushCallback) {
 		return false
 	}
 
-	if msg.Type() == RequestType && !msg.NoReply() {
-		response := msg.createResponse()
-		writer := response.asyncRead(func(err error) {
-			msg.responseComplete(response)
-		})
-		sender.receiver.awaitResponse(response, writer)
-	}
 	return true
 }
 


### PR DESCRIPTION
Fixes https://github.com/couchbase/sync_gateway/issues/3221

## Main fix

- Addresses race condition described in https://github.com/couchbase/sync_gateway/issues/3221#issuecomment-363929059 by allowing a `prePushMsgCallback()` function to be passed into `messageQueue.push()`
- Split out `messageQueue.push()` into `messageQueue.push()` and `messageQueue.pushWithCallback()`


## Other changes

- Add ability to customize the blip context ID, which is useful to further differentiate the different blip contexts during testing (see https://gist.github.com/tleyden/1f0aebbe7e7465858747b6aef4582fda for example)
- Add another test.  It doesn't repro the issue, but I left it in as a regression test

