### PR TITLE
Fixes #24 Update WebSocket protocol to “BLIP_3"

### DIFF
--- a/context.go
+++ b/context.go
@@ -52,20 +52,20 @@ type LogContext interface {
 //////// SETUP:
 
 // Creates a new Context with an empty dispatch table.
-func NewContext(AppProtocolId string) *Context {
-	return NewContextCustomID(fmt.Sprintf("%x", rand.Int31()), AppProtocolId)
+func NewContext(appProtocolId string) *Context {
+	return NewContextCustomID(fmt.Sprintf("%x", rand.Int31()), appProtocolId)
 }
 
 // Creates a new Context with a custom ID, which can be helpful to differentiate logs between other blip contexts
 // in the same process. The AppProtocolId ensures that this client will only connect to peers that have agreed
 // upon the same application layer level usage of BLIP.  For example "CBMobile_2" is the AppProtocolId for the
 // Couchbase Mobile replication protocol.
-func NewContextCustomID(id string, AppProtocolId string) *Context {
+func NewContextCustomID(id string, appProtocolId string) *Context {
 	return &Context{
 		HandlerForProfile:    map[string]Handler{},
 		Logger:               logPrintfWrapper(),
 		ID:                   id,
-		WebSocketSubProtocol: NewWebSocketSubProtocol(AppProtocolId),
+		WebSocketSubProtocol: NewWebSocketSubProtocol(appProtocolId),
 	}
 }
 

--- a/context.go
+++ b/context.go
@@ -29,13 +29,13 @@ type Context struct {
 	// Client request must indicate that it supports this protocol, else WebSocket handshake will fail.
 	WebSocketSubProtocol string
 
-	HandlerForProfile    map[string]Handler // Handler function for a request Profile
-	DefaultHandler       Handler            // Handler for all otherwise unhandled requests
-	FatalErrorHandler    func(error)        // Called when connection has a fatal error
-	MaxSendQueueCount    int                // Max # of messages being sent at once (if >0)
-	Logger               LogFn              // Logging callback; defaults to log.Printf
-	LogMessages          bool               // If true, will log about messages
-	LogFrames            bool               // If true, will log about frames (very verbose)
+	HandlerForProfile map[string]Handler // Handler function for a request Profile
+	DefaultHandler    Handler            // Handler for all otherwise unhandled requests
+	FatalErrorHandler func(error)        // Called when connection has a fatal error
+	MaxSendQueueCount int                // Max # of messages being sent at once (if >0)
+	Logger            LogFn              // Logging callback; defaults to log.Printf
+	LogMessages       bool               // If true, will log about messages
+	LogFrames         bool               // If true, will log about frames (very verbose)
 
 	// An identifier that uniquely defines the context.  NOTE: Random Number Generator not seeded by go-blip.
 	ID string
@@ -52,18 +52,20 @@ type LogContext interface {
 //////// SETUP:
 
 // Creates a new Context with an empty dispatch table.
-func NewContext(WebSocketSubProtocol string) *Context {
-	return NewContextCustomID(fmt.Sprintf("%x", rand.Int31()), WebSocketSubProtocol)
+func NewContext(AppProtocolId string) *Context {
+	return NewContextCustomID(fmt.Sprintf("%x", rand.Int31()), AppProtocolId)
 }
 
 // Creates a new Context with a custom ID, which can be helpful to differentiate logs between other blip contexts
-// in the same process.
-func NewContextCustomID(id string, WebSocketSubProtocol string) *Context {
+// in the same process. The AppProtocolId ensures that this client will only connect to peers that have agreed
+// upon the same application layer level usage of BLIP.  For example "CBMobile_2" is the AppProtocolId for the
+// Couchbase Mobile replication protocol.
+func NewContextCustomID(id string, AppProtocolId string) *Context {
 	return &Context{
 		HandlerForProfile:    map[string]Handler{},
 		Logger:               logPrintfWrapper(),
 		ID:                   id,
-		WebSocketSubProtocol: WebSocketSubProtocol,
+		WebSocketSubProtocol: NewWebSocketSubProtocol(AppProtocolId),
 	}
 }
 

--- a/context_test.go
+++ b/context_test.go
@@ -13,8 +13,8 @@ import (
 	"golang.org/x/net/websocket"
 )
 
-
-const TestWebsocketSubprotocol = "BLIP_3+Test"
+// The application protocol id of the BLIP websocket subprotocol used in go-blip unit tests
+const BlipTestAppProtocolId = "GoBlipUnitTests"
 
 // This was added in reaction to https://github.com/couchbase/sync_gateway/issues/3268 to either
 // confirm or deny erroneous behavior w.r.t sockets being abruptly closed.  The main question attempted
@@ -33,7 +33,7 @@ const TestWebsocketSubprotocol = "BLIP_3+Test"
 //
 func TestServerAbruptlyCloseConnectionBehavior(t *testing.T) {
 
-	blipContextEchoServer := NewContext(TestWebsocketSubprotocol)
+	blipContextEchoServer := NewContext(BlipTestAppProtocolId)
 
 	receivedRequests := sync.WaitGroup{}
 
@@ -87,7 +87,7 @@ func TestServerAbruptlyCloseConnectionBehavior(t *testing.T) {
 
 	// ----------------- Setup Echo Client ----------------------------------------
 
-	blipContextEchoClient := NewContext(TestWebsocketSubprotocol)
+	blipContextEchoClient := NewContext(BlipTestAppProtocolId)
 	port := listener.Addr().(*net.TCPAddr).Port
 	destUrl := fmt.Sprintf("ws://localhost:%d/TestServerAbruptlyCloseConnectionBehavior", port)
 	sender, err := blipContextEchoClient.Dial(destUrl, "http://localhost")
@@ -168,7 +168,7 @@ The test does the following steps:
 */
 func TestClientAbruptlyCloseConnectionBehavior(t *testing.T) {
 
-	blipContextEchoServer := NewContext(TestWebsocketSubprotocol)
+	blipContextEchoServer := NewContext(BlipTestAppProtocolId)
 
 	receivedEchoRequest := sync.WaitGroup{}
 	echoAmplifyRoundTripComplete := sync.WaitGroup{}
@@ -244,7 +244,7 @@ func TestClientAbruptlyCloseConnectionBehavior(t *testing.T) {
 
 	// ----------------- Setup Echo Client ----------------------------------------
 
-	blipContextEchoClient := NewContext(TestWebsocketSubprotocol)
+	blipContextEchoClient := NewContext(BlipTestAppProtocolId)
 	port := listener.Addr().(*net.TCPAddr).Port
 	destUrl := fmt.Sprintf("ws://localhost:%d/TestClientAbruptlyCloseConnectionBehavior", port)
 	sender, err := blipContextEchoClient.Dial(destUrl, "http://localhost")
@@ -292,7 +292,6 @@ func TestClientAbruptlyCloseConnectionBehavior(t *testing.T) {
 
 }
 
-
 func TestIncludesProtocol(t *testing.T) {
 
 	headersWithExpectedResponses := []struct {
@@ -301,32 +300,29 @@ func TestIncludesProtocol(t *testing.T) {
 		MatchedSubprotocol string
 	}{
 		{
-			Header:             TestWebsocketSubprotocol,
-			ExpectedResponse:   true,
+			Header:           BlipTestAppProtocolId,
+			ExpectedResponse: true,
 		},
 		{
-			Header:             TestWebsocketSubprotocol +",SomeOtherWebsocketSubprotocol",
-			ExpectedResponse:   true,
+			Header:           BlipTestAppProtocolId + ",SomeOtherWebsocketSubprotocol",
+			ExpectedResponse: true,
 		},
 		{
-			Header:             "SomeOtherWebsocketSubprotocol," + TestWebsocketSubprotocol,
-			ExpectedResponse:   true,
+			Header:           "SomeOtherWebsocketSubprotocol," + BlipTestAppProtocolId,
+			ExpectedResponse: true,
 		},
 		{
-			Header:             "SomeOtherWebsocketSubprotocol",
-			ExpectedResponse:   false,
+			Header:           "SomeOtherWebsocketSubprotocol",
+			ExpectedResponse: false,
 		},
-
 	}
 
 	for _, headerWithExpectedResponse := range headersWithExpectedResponses {
-		matched := includesProtocol(headerWithExpectedResponse.Header, TestWebsocketSubprotocol)
+		matched := includesProtocol(headerWithExpectedResponse.Header, BlipTestAppProtocolId)
 		assert.Equals(t, matched, headerWithExpectedResponse.ExpectedResponse)
 	}
 
 }
-
-
 
 // Wait for the WaitGroup, or return an error if the wg.Wait() doesn't return within timeout
 // TODO: this code is duplicated with code in Sync Gateway utilities_testing.go.  Should be refactored to common repo.

--- a/example/cmd/responder.go
+++ b/example/cmd/responder.go
@@ -15,7 +15,9 @@ import (
 const (
 	verbosity = 0
 	kInterface = ":12345"
-	ExampleWebsocketSubprotocol = "BLIP_3+Example"
+
+	// The application protocol id of the BLIP websocket subprotocol used by go-blip examples
+	BlipExampleAppProtocolId = "GoBlipExample"
 )
 
 // This program acts as a listener equivalent to the Objective-C one in MYNetwork's
@@ -39,7 +41,7 @@ func responder() {
 	runtime.GOMAXPROCS(maxProcs)
 	log.Printf("Set GOMAXPROCS to %d", maxProcs)
 
-	context := blip.NewContext(ExampleWebsocketSubprotocol)
+	context := blip.NewContext(BlipExampleAppProtocolId)
 	context.HandlerForProfile["BLIPTest/EchoData"] = dispatchEcho
 	context.LogMessages = verbosity > 1
 	context.LogFrames = verbosity > 2

--- a/example/cmd/responder.go
+++ b/example/cmd/responder.go
@@ -11,9 +11,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const verbosity = 0
 
-const kInterface = ":12345"
+const (
+	verbosity = 0
+	kInterface = ":12345"
+	ExampleWebsocketSubprotocol = "BLIP_3+Example"
+)
 
 // This program acts as a listener equivalent to the Objective-C one in MYNetwork's
 // BLIPWebSocketTest.m.
@@ -36,7 +39,7 @@ func responder() {
 	runtime.GOMAXPROCS(maxProcs)
 	log.Printf("Set GOMAXPROCS to %d", maxProcs)
 
-	context := blip.NewContext()
+	context := blip.NewContext(ExampleWebsocketSubprotocol)
 	context.HandlerForProfile["BLIPTest/EchoData"] = dispatchEcho
 	context.LogMessages = verbosity > 1
 	context.LogFrames = verbosity > 2

--- a/example/cmd/sendtest.go
+++ b/example/cmd/sendtest.go
@@ -50,7 +50,7 @@ func sender() {
 	runtime.GOMAXPROCS(maxProcs)
 	log.Printf("Set GOMAXPROCS to %d", maxProcs)
 
-	context := blip.NewContext(ExampleWebsocketSubprotocol)
+	context := blip.NewContext(BlipExampleAppProtocolId)
 	context.MaxSendQueueCount = kMaxSendQueueCount
 	context.LogMessages = verbosity > 1
 	context.LogFrames = verbosity > 2

--- a/example/cmd/sendtest.go
+++ b/example/cmd/sendtest.go
@@ -50,7 +50,7 @@ func sender() {
 	runtime.GOMAXPROCS(maxProcs)
 	log.Printf("Set GOMAXPROCS to %d", maxProcs)
 
-	context := blip.NewContext()
+	context := blip.NewContext(ExampleWebsocketSubprotocol)
 	context.MaxSendQueueCount = kMaxSendQueueCount
 	context.LogMessages = verbosity > 1
 	context.LogFrames = verbosity > 2

--- a/functional_test.go
+++ b/functional_test.go
@@ -19,7 +19,7 @@ import (
 // aka a "functional test".
 func TestEchoRoundTrip(t *testing.T) {
 
-	blipContextEchoServer := NewContext(TestWebsocketSubprotocol)
+	blipContextEchoServer := NewContext(BlipTestAppProtocolId)
 
 	receivedRequests := sync.WaitGroup{}
 
@@ -70,7 +70,7 @@ func TestEchoRoundTrip(t *testing.T) {
 
 	// ----------------- Setup Echo Client ----------------------------------------
 
-	blipContextEchoClient := NewContext(TestWebsocketSubprotocol)
+	blipContextEchoClient := NewContext(BlipTestAppProtocolId)
 	port := listener.Addr().(*net.TCPAddr).Port
 	destUrl := fmt.Sprintf("ws://localhost:%d/blip", port)
 	sender, err := blipContextEchoClient.Dial(destUrl, "http://localhost")

--- a/functional_test.go
+++ b/functional_test.go
@@ -19,7 +19,7 @@ import (
 // aka a "functional test".
 func TestEchoRoundTrip(t *testing.T) {
 
-	blipContextEchoServer := NewContext()
+	blipContextEchoServer := NewContext(TestWebsocketSubprotocol)
 
 	receivedRequests := sync.WaitGroup{}
 
@@ -70,7 +70,7 @@ func TestEchoRoundTrip(t *testing.T) {
 
 	// ----------------- Setup Echo Client ----------------------------------------
 
-	blipContextEchoClient := NewContext()
+	blipContextEchoClient := NewContext(TestWebsocketSubprotocol)
 	port := listener.Addr().(*net.TCPAddr).Port
 	destUrl := fmt.Sprintf("ws://localhost:%d/blip", port)
 	sender, err := blipContextEchoClient.Dial(destUrl, "http://localhost")

--- a/protocol.go
+++ b/protocol.go
@@ -1,5 +1,14 @@
 package blip
 
+import "fmt"
+
+// WebSocket [sub]protocol prefix for BLIP, used during WebSocket handshake.
+// Client request must indicate that it supports this protocol, else the handshake will fail.
+// The full websocket subprotocol will also have an identifier for the application layer protocol:
+// <WebSocketSubProtocolPrefix>+<AppProtocolId>, eg BLIP_3+CBMobile_2.
+// Every sub-protocol used by a caller should begin with this string.
+const WebSocketSubProtocolPrefix = "BLIP_3"
+
 // Domain used in errors returned by BLIP itself.
 const BLIPErrorDomain = "BLIP"
 
@@ -58,6 +67,13 @@ const (
 
 func (f frameFlags) messageType() MessageType {
 	return MessageType(f & kTypeMask)
+}
+
+///////// HELPER UTILS:
+
+// Create a new Websocket subprotocol using the given application protocol identifier.
+func NewWebSocketSubProtocol(AppProtocolId string) string {
+	return fmt.Sprintf("%s+%s", WebSocketSubProtocolPrefix, AppProtocolId)
 }
 
 //  Copyright (c) 2013 Jens Alfke. Copyright (c) 2015-2017 Couchbase, Inc.

--- a/protocol.go
+++ b/protocol.go
@@ -1,9 +1,5 @@
 package blip
 
-// WebSocket [sub]protocol name for BLIP, used during WebSocket handshake.
-// Client request must indicate that it supports this protocol, else the handshake will fail.
-const WebSocketProtocolName = "BLIP_3a2"
-
 // Domain used in errors returned by BLIP itself.
 const BLIPErrorDomain = "BLIP"
 


### PR DESCRIPTION
## Testing

- [ ] Added unit test `TestIncludesProtocol` to test `includesProtocol()` in isolation
- [ ] Test the litecore blip replication test "API Continuous Push" after modifying `kWSProtocolName` to be `BLIP_3` and `BLIP_3+CBMobile_2` (in `BLIPConnection.hh`)