### PR TITLE
Set UseNumber when decoding message bodies

### DIFF
--- a/message.go
+++ b/message.go
@@ -180,7 +180,9 @@ func (m *Message) ReadJSONBody(value interface{}) error {
 	if bodyReader, err := m.BodyReader(); err != nil {
 		return err
 	} else {
-		return json.NewDecoder(bodyReader).Decode(value)
+		decoder := json.NewDecoder(bodyReader)
+		decoder.UseNumber()
+		return decoder.Decode(value)
 	}
 }
 


### PR DESCRIPTION
Preserves number formatting when unmarshalling numbers to interface{}.

Part of fix for https://github.com/couchbase/sync_gateway/issues/3783