### PR TITLE
CBG-279 Fix leak in nextFrameToSend by closing message encoder

### DIFF
--- a/message.go
+++ b/message.go
@@ -26,12 +26,23 @@ type Message struct {
 	bytesAcked uint64
 
 	reader       io.ReadCloser // Stream that an incoming message is being read from
-	encoder      io.Reader     // Stream that an outgoing message is being written to
+	encoder      io.ReadCloser // Stream that an outgoing message is being written to
 	readingBody  bool          // True if reader stream has been accessed by client already
 	complete     bool          // Has this message been completely received?
 	response     *Message      // Response to this message, if it's a request
 	inResponseTo *Message      // Message this is a response to
 	cond         *sync.Cond    // Used to make Response() method block until response arrives
+}
+
+// Closes all resources for the message.
+func (message *Message) Close() error {
+	if message.reader != nil {
+		_ = message.reader.Close()
+	}
+	if message.encoder != nil {
+		_ = message.encoder.Close()
+	}
+	return nil
 }
 
 // Returns a string describing the message for debugging purposes

--- a/message.go
+++ b/message.go
@@ -35,14 +35,14 @@ type Message struct {
 }
 
 // Closes all resources for the message.
-func (message *Message) Close() error {
+func (message *Message) Close() (err error) {
 	if message.reader != nil {
-		_ = message.reader.Close()
+		err = message.reader.Close()
 	}
 	if message.encoder != nil {
-		_ = message.encoder.Close()
+		err = message.encoder.Close()
 	}
-	return nil
+	return err
 }
 
 // Returns a string describing the message for debugging purposes

--- a/messagequeue.go
+++ b/messagequeue.go
@@ -149,23 +149,18 @@ func (q *messageQueue) stop() {
 	q.cond.L.Lock()
 	defer q.cond.L.Unlock()
 
-
 	// Iterate over messages and call close on every message's readcloser, since it's possible that
 	// a goroutine may be blocked on the reader, thus causing a resource leak.  Added during SG #3268
 	// diagnosis, but does not fix any reproducible issues.
 	for _, message := range q.queue {
-		if message.reader == nil {
-			continue
-		}
-		err := message.reader.Close()
+		err := message.Close()
 		if err != nil {
-			q.logContext.logMessage("Warning: messageQueue encountered error closing message reader while stopping. Error: %v", err)
+			q.logContext.logMessage("Warning: messageQueue encountered error closing message while stopping. Error: %v", err)
 		}
 	}
 
 	q.queue = nil
 	q.cond.Broadcast()
-
 
 }
 

--- a/messagequeue_test.go
+++ b/messagequeue_test.go
@@ -2,11 +2,12 @@ package blip
 
 import (
 	"bytes"
+	"io/ioutil"
 	"log"
 	"sync"
 	"testing"
 
-	"github.com/couchbaselabs/go.assert"
+	assert "github.com/couchbaselabs/go.assert"
 )
 
 func TestMessagePushPop(t *testing.T) {
@@ -146,7 +147,7 @@ func TestUrgentMessageOrdering(t *testing.T) { // Test passes, but some assertio
 		assert.False(t, mq.nextMessageIsUrgent())
 
 		// set the msg.encoder to something so that the next urgent message will go to the head of the line
-		msg.encoder = &bytes.Buffer{}
+		msg.encoder = ioutil.NopCloser(&bytes.Buffer{})
 
 	}
 

--- a/sender.go
+++ b/sender.go
@@ -163,6 +163,9 @@ func (sender *Sender) start() {
 			_, err := sender.conn.Write(frameBuffer.Bytes()) // See #19 for details on why it ignores num bytes written.
 			if err != nil {
 				sender.context.logFrame("Sender error writing framebuffer (len=%d). Error: %v", len(frameBuffer.Bytes()), err)
+				if err := msg.Close(); err != nil {
+					sender.context.logFrame("Sender error closing message. Error: %v", err)
+				}
 			}
 			frameBuffer.Reset()
 


### PR DESCRIPTION
When sending a message over BLIP, and that message is large enough to span multiple frames, `nextFrameToSend()` leaks its encoder writer goroutine and it never unblocks on `m.WriteTo()` when `sender.conn.Write()` errors in the main BLIP sender loop.

This can be seen in the expvars, as goblip.goroutines_next_frame_to_send:93, and observed in goroutine profiles

Changes
=======
- Switch `Message.encoder` to be a `ReadCloser` interface.
- Add `Message.Close()` method to close both underlying message reader and message encoder.
- Call `Message.Close()` when the sender encounters an error sending a frame over the network.
- Switch `messageQueue.Stop()` to use `message.Close()`