### PR TITLE
Add WebsocketPingInterval option

### DIFF
--- a/context.go
+++ b/context.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"runtime/debug"
 	"strings"
+	"time"
 
 	"golang.org/x/net/websocket"
 )
@@ -36,6 +37,8 @@ type Context struct {
 	Logger            LogFn              // Logging callback; defaults to log.Printf
 	LogMessages       bool               // If true, will log about messages
 	LogFrames         bool               // If true, will log about frames (very verbose)
+
+	WebsocketPingInterval time.Duration // Time between sending ping frames (if >0)
 
 	// An identifier that uniquely defines the context.  NOTE: Random Number Generator not seeded by go-blip.
 	ID string

--- a/expvar.go
+++ b/expvar.go
@@ -4,45 +4,57 @@ import "expvar"
 
 // Expvar instrumentation
 var (
-	numGoroutines = expvar.NewMap("goblip")
+	goblipExpvar = expvar.NewMap("goblip")
 )
 
 func incrReceiverGoroutines() {
-	numGoroutines.Add("goroutines_receiver", 1)
+	goblipExpvar.Add("goroutines_receiver", 1)
 }
 
 func decrReceiverGoroutines() {
-	numGoroutines.Add("goroutines_receiver", -1)
+	goblipExpvar.Add("goroutines_receiver", -1)
 }
 
 func incrAsyncReadGoroutines() {
-	numGoroutines.Add("goroutines_async_read", 1)
+	goblipExpvar.Add("goroutines_async_read", 1)
 }
 
 func decrAsyncReadGoroutines() {
-	numGoroutines.Add("goroutines_async_read", -1)
+	goblipExpvar.Add("goroutines_async_read", -1)
 }
 
 func incrNextFrameToSendGoroutines() {
-	numGoroutines.Add("goroutines_next_frame_to_send", 1)
+	goblipExpvar.Add("goroutines_next_frame_to_send", 1)
 }
 
 func decrNextFrameToSendGoroutines() {
-	numGoroutines.Add("goroutines_next_frame_to_send", -1)
+	goblipExpvar.Add("goroutines_next_frame_to_send", -1)
 }
 
 func incrParseLoopGoroutines() {
-	numGoroutines.Add("goroutines_parse_loop", 1)
+	goblipExpvar.Add("goroutines_parse_loop", 1)
 }
 
 func decrParseLoopGoroutines() {
-	numGoroutines.Add("goroutines_parse_loop", -1)
+	goblipExpvar.Add("goroutines_parse_loop", -1)
 }
 
 func incrSenderGoroutines() {
-	numGoroutines.Add("goroutines_sender", 1)
+	goblipExpvar.Add("goroutines_sender", 1)
 }
 
 func decrSenderGoroutines() {
-	numGoroutines.Add("goroutines_sender", -1)
+	goblipExpvar.Add("goroutines_sender", -1)
+}
+
+func incrSenderPingCount() {
+	goblipExpvar.Add("sender_ping_count", 1)
+}
+
+func incrSenderPingGoroutines() {
+	goblipExpvar.Add("goroutines_sender_ping", 1)
+}
+
+func decrSenderPingGoroutines() {
+	goblipExpvar.Add("goroutines_sender_ping", -1)
 }

--- a/functional_test.go
+++ b/functional_test.go
@@ -62,13 +62,14 @@ func TestEchoRoundTrip(t *testing.T) {
 	}
 
 	// HTTP Handler wrapping websocket server
-	http.Handle("/blip", defaultHandler)
+	mux := http.NewServeMux()
+	mux.Handle("/blip", defaultHandler)
 	listener, err := net.Listen("tcp", ":0")
 	if err != nil {
 		panic(err)
 	}
 	go func() {
-		panic(http.Serve(listener, nil))
+		panic(http.Serve(listener, mux))
 	}()
 
 	// ----------------- Setup Echo Client ----------------------------------------
@@ -122,13 +123,14 @@ func TestSenderPing(t *testing.T) {
 		}()
 		defaultHandler(conn)
 	}
-	http.Handle("/blip", defaultHandler)
+	mux := http.NewServeMux()
+	mux.Handle("/blip", defaultHandler)
 	listener, err := net.Listen("tcp", ":0")
 	if err != nil {
 		panic(err)
 	}
 	go func() {
-		panic(http.Serve(listener, nil))
+		panic(http.Serve(listener, mux))
 	}()
 
 	// client

--- a/sender.go
+++ b/sender.go
@@ -201,9 +201,11 @@ func (sender *Sender) start() {
 			defer tick.Stop()
 			for range tick.C {
 				if err := codec.Send(sender.conn, nil); err != nil {
-					sender.context.logFrame("Sender error sending ping frame. Error: %v", err)
-					if strings.Contains(err.Error(), "use of closed network connection") {
-						// exit the goroutine if the connection has gone
+					errMsg := err.Error()
+					sender.context.logFrame("Sender error sending ping frame. Error: %s", errMsg)
+					if strings.Contains(errMsg, "use of closed network connection") ||
+						strings.Contains(errMsg, "broken pipe") ||
+						strings.Contains(errMsg, "connection reset") {
 						return
 					}
 				}


### PR DESCRIPTION
If the blip.Context's `WebsocketPingInterval` duration is non-zero, it spawns an additional sender goroutine, and periodically sends Websocket Ping frames.

![Screenshot_2020-06-25_13-48-04](https://user-images.githubusercontent.com/1525809/85722969-b3996b00-b6ea-11ea-9bf5-ef3c873dc19b.png)
