### PR TITLE
CBG-1435: Allow multiple protocols to be supported

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
     agent { label 'sync-gateway-pipeline-builder' }
 
     environment {
-        GO_VERSION = 'go1.11.5'
+        GO_VERSION = 'go1.13.4'
         GVM = "/root/.gvm/bin/gvm"
         GO = "/root/.gvm/gos/${GO_VERSION}/bin"
         GOPATH = "${WORKSPACE}/gopath"

--- a/context.go
+++ b/context.go
@@ -87,18 +87,18 @@ func (context *Context) start(ws *websocket.Conn) *Sender {
 // Opens a BLIP connection to a host.
 // appProtocolIds specifies the sub protocols the client wishes to talk in. This is an ordered list, the first protocol
 // will be the one that is attempted first
-func (context *Context) Dial(url string, origin string, appProtocolIds ...string) (*Sender, error) {
+func (context *Context) Dial(url string, origin string) (*Sender, error) {
 	config, err := websocket.NewConfig(url, origin)
 	if err != nil {
 		return nil, err
 	}
-	return context.DialConfig(config, appProtocolIds...)
+	return context.DialConfig(config)
 }
 
 // Opens a BLIP connection to a host given a websocket.Config, which allows the caller to specify Authorization header.
 // appProtocolIds specifies the sub protocols the client wishes to talk in. This is an ordered list, the first protocol
 // will be the one that is attempted first
-func (context *Context) DialConfig(config *websocket.Config, appProtocolIds ...string) (*Sender, error) {
+func (context *Context) DialConfig(config *websocket.Config) (*Sender, error) {
 
 	var ws *websocket.Conn
 	var err error
@@ -108,8 +108,7 @@ func (context *Context) DialConfig(config *websocket.Config, appProtocolIds ...s
 	// The first one that the server also supports will result in no error and us continuing with the function
 	// Otherwise iterate until we find one
 	// If one isn't found quit out and return the error
-	for _, subProtocol := range appProtocolIds {
-		subProtocol = NewWebSocketSubProtocol(subProtocol)
+	for _, subProtocol := range context.SupportedSubProtocols {
 		config.Protocol = []string{subProtocol}
 		ws, err = websocket.DialConfig(config)
 		if err != nil {

--- a/context.go
+++ b/context.go
@@ -60,7 +60,7 @@ type LogContext interface {
 //////// SETUP:
 
 // Creates a new Context with an empty dispatch table.
-func NewContext(appProtocolIds ...string) *Context {
+func NewContext(appProtocolIds ...string) (*Context, error) {
 	return NewContextCustomID(fmt.Sprintf("%x", rand.Int31()), appProtocolIds...)
 }
 
@@ -68,13 +68,17 @@ func NewContext(appProtocolIds ...string) *Context {
 // in the same process. The AppProtocolId ensures that this client will only connect to peers that have agreed
 // upon the same application layer level usage of BLIP.  For example "CBMobile_2" is the AppProtocolId for the
 // Couchbase Mobile replication protocol.
-func NewContextCustomID(id string, appProtocolIds ...string) *Context {
+func NewContextCustomID(id string, appProtocolIds ...string) (*Context, error) {
+	if len(appProtocolIds) == 0 {
+		return nil, fmt.Errorf("provided protocolIds cannot be empty")
+	}
+
 	return &Context{
 		HandlerForProfile:     map[string]Handler{},
 		Logger:                logPrintfWrapper(),
 		ID:                    id,
 		SupportedSubProtocols: FormatWebSocketSubProtocols(appProtocolIds...),
-	}
+	}, nil
 }
 
 func (context *Context) start(ws *websocket.Conn) *Sender {

--- a/context.go
+++ b/context.go
@@ -85,8 +85,6 @@ func (context *Context) start(ws *websocket.Conn) *Sender {
 }
 
 // Opens a BLIP connection to a host.
-// appProtocolIds specifies the sub protocols the client wishes to talk in. This is an ordered list, the first protocol
-// will be the one that is attempted first
 func (context *Context) Dial(url string, origin string) (*Sender, error) {
 	config, err := websocket.NewConfig(url, origin)
 	if err != nil {
@@ -96,8 +94,6 @@ func (context *Context) Dial(url string, origin string) (*Sender, error) {
 }
 
 // Opens a BLIP connection to a host given a websocket.Config, which allows the caller to specify Authorization header.
-// appProtocolIds specifies the sub protocols the client wishes to talk in. This is an ordered list, the first protocol
-// will be the one that is attempted first
 func (context *Context) DialConfig(config *websocket.Config) (*Sender, error) {
 
 	var ws *websocket.Conn

--- a/context_test.go
+++ b/context_test.go
@@ -33,7 +33,10 @@ const BlipTestAppProtocolId = "GoBlipUnitTests"
 //
 func TestServerAbruptlyCloseConnectionBehavior(t *testing.T) {
 
-	blipContextEchoServer := NewContext(BlipTestAppProtocolId)
+	blipContextEchoServer, err := NewContext(BlipTestAppProtocolId)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	receivedRequests := sync.WaitGroup{}
 
@@ -87,7 +90,10 @@ func TestServerAbruptlyCloseConnectionBehavior(t *testing.T) {
 
 	// ----------------- Setup Echo Client ----------------------------------------
 
-	blipContextEchoClient := NewContext(BlipTestAppProtocolId)
+	blipContextEchoClient, err := NewContext(BlipTestAppProtocolId)
+	if err != nil {
+		t.Fatal(err)
+	}
 	port := listener.Addr().(*net.TCPAddr).Port
 	destUrl := fmt.Sprintf("ws://localhost:%d/TestServerAbruptlyCloseConnectionBehavior", port)
 	sender, err := blipContextEchoClient.Dial(destUrl, "http://localhost")
@@ -168,7 +174,10 @@ The test does the following steps:
 */
 func TestClientAbruptlyCloseConnectionBehavior(t *testing.T) {
 
-	blipContextEchoServer := NewContext(BlipTestAppProtocolId)
+	blipContextEchoServer, err := NewContext(BlipTestAppProtocolId)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	receivedEchoRequest := sync.WaitGroup{}
 	echoAmplifyRoundTripComplete := sync.WaitGroup{}
@@ -244,7 +253,10 @@ func TestClientAbruptlyCloseConnectionBehavior(t *testing.T) {
 
 	// ----------------- Setup Echo Client ----------------------------------------
 
-	blipContextEchoClient := NewContext(BlipTestAppProtocolId)
+	blipContextEchoClient, err := NewContext(BlipTestAppProtocolId)
+	if err != nil {
+		t.Fatal(err)
+	}
 	port := listener.Addr().(*net.TCPAddr).Port
 	destUrl := fmt.Sprintf("ws://localhost:%d/TestClientAbruptlyCloseConnectionBehavior", port)
 	sender, err := blipContextEchoClient.Dial(destUrl, "http://localhost")
@@ -371,7 +383,10 @@ func TestUnsupportedSubProtocol(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			serverCtx := NewContext(testCase.ServerProtocols...)
+			serverCtx, err := NewContext(testCase.ServerProtocols...)
+			if err != nil {
+				t.Fatal(err)
+			}
 			serverCtx.LogMessages = true
 			serverCtx.LogFrames = true
 
@@ -399,7 +414,10 @@ func TestUnsupportedSubProtocol(t *testing.T) {
 			}()
 
 			// Client
-			client := NewContext(testCase.ClientProtocol...)
+			client, err := NewContext(testCase.ClientProtocol...)
+			if err != nil {
+				t.Fatal(err)
+			}
 			port := listener.Addr().(*net.TCPAddr).Port
 			destUrl := fmt.Sprintf("ws://localhost:%d/someBlip", port)
 			_, err = client.Dial(destUrl, "http://localhost")

--- a/context_test.go
+++ b/context_test.go
@@ -9,8 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	assert "github.com/couchbaselabs/go.assert"
 	"golang.org/x/net/websocket"
 )
 
@@ -286,7 +285,7 @@ func TestClientAbruptlyCloseConnectionBehavior(t *testing.T) {
 
 	// Assertions about echo response (these might need to be altered, maybe what's expected in this scenario is actually an error)
 	assert.True(t, err == nil)
-	assert.Equal(t, string(responseBody), "hello")
+	assert.Equals(t, string(responseBody), "hello")
 
 	// Wait until the amplify request was received by client (from server), and that the server read the response
 	WaitWithTimeout(&echoAmplifyRoundTripComplete, time.Second*60)
@@ -320,7 +319,7 @@ func TestIncludesProtocol(t *testing.T) {
 
 	for _, headerWithExpectedResponse := range headersWithExpectedResponses {
 		_, matched := includesProtocol(headerWithExpectedResponse.Header, []string{BlipTestAppProtocolId})
-		assert.Equal(t, matched, headerWithExpectedResponse.ExpectedResponse)
+		assert.Equals(t, matched, headerWithExpectedResponse.ExpectedResponse)
 	}
 
 }
@@ -374,11 +373,15 @@ func TestUnsupportedSubProtocol(t *testing.T) {
 			mux := http.NewServeMux()
 			mux.Handle("/someBlip", server)
 			listener, err := net.Listen("tcp", ":0")
-			require.NoError(t, err)
+			if err != nil {
+				panic(err)
+			}
 
 			go func() {
 				err := http.Serve(listener, mux)
-				require.NoError(t, err)
+				if err != nil {
+					panic(err)
+				}
 			}()
 
 			// Client
@@ -388,13 +391,13 @@ func TestUnsupportedSubProtocol(t *testing.T) {
 			_, err = client.Dial(destUrl, "http://localhost", testCase.ClientProtocol)
 
 			if testCase.ExpectError {
-				assert.Error(t, err)
+				assert.True(t, err != nil)
 			} else {
-				assert.NoError(t, err)
+				assert.Equals(t, err, nil)
 			}
 
 			if testCase.ActiveProtocol != "" {
-				assert.Equal(t, testCase.ActiveProtocol, serverCtx.ActiveProtocol())
+				assert.Equals(t, serverCtx.ActiveProtocol(), testCase.ActiveProtocol)
 			}
 		})
 	}

--- a/context_test.go
+++ b/context_test.go
@@ -326,32 +326,46 @@ func TestIncludesProtocol(t *testing.T) {
 
 func TestUnsupportedSubProtocol(t *testing.T) {
 	testCases := []struct {
-		Name            string
-		ServerProtocols []string
-		ClientProtocol  string
-		ActiveProtocol  string
-		ExpectError     bool
+		Name                 string
+		ServerProtocols      []string
+		ClientProtocol       []string
+		ActiveServerProtocol string
+		ExpectError          bool
 	}{
 		{
-			Name:            "Unsupported",
-			ServerProtocols: []string{"V2"},
-			ClientProtocol:  "V1",
-			ActiveProtocol:  "",
-			ExpectError:     true,
+			Name:                 "Unsupported",
+			ServerProtocols:      []string{"V2"},
+			ClientProtocol:       []string{"V1"},
+			ActiveServerProtocol: "",
+			ExpectError:          true,
 		},
 		{
-			Name:            "SupportedOne",
-			ServerProtocols: []string{"V1"},
-			ClientProtocol:  "V1",
-			ActiveProtocol:  "V1",
-			ExpectError:     false,
+			Name:                 "SupportedOne",
+			ServerProtocols:      []string{"V1"},
+			ClientProtocol:       []string{"V1"},
+			ActiveServerProtocol: "V1",
+			ExpectError:          false,
 		},
 		{
-			Name:            "SupportedTwo",
-			ServerProtocols: []string{"V1", "V2"},
-			ActiveProtocol:  "V1",
-			ClientProtocol:  "V1",
-			ExpectError:     false,
+			Name:                 "SupportedTwo",
+			ServerProtocols:      []string{"V1", "V2"},
+			ClientProtocol:       []string{"V1"},
+			ActiveServerProtocol: "V1",
+			ExpectError:          false,
+		},
+		{
+			Name:                 "ClientAndServerSupportsTwoV1First",
+			ServerProtocols:      []string{"V1", "V2"},
+			ClientProtocol:       []string{"V1", "V2"},
+			ActiveServerProtocol: "V1",
+			ExpectError:          false,
+		},
+		{
+			Name:                 "ClientAndServerSupportsTwoV2First",
+			ServerProtocols:      []string{"V1", "V2"},
+			ClientProtocol:       []string{"V2", "V1"},
+			ActiveServerProtocol: "V2",
+			ExpectError:          false,
 		},
 	}
 
@@ -388,7 +402,7 @@ func TestUnsupportedSubProtocol(t *testing.T) {
 			client := NewContext()
 			port := listener.Addr().(*net.TCPAddr).Port
 			destUrl := fmt.Sprintf("ws://localhost:%d/someBlip", port)
-			_, err = client.Dial(destUrl, "http://localhost", testCase.ClientProtocol)
+			_, err = client.Dial(destUrl, "http://localhost", testCase.ClientProtocol...)
 
 			if testCase.ExpectError {
 				assert.True(t, err != nil)
@@ -396,8 +410,9 @@ func TestUnsupportedSubProtocol(t *testing.T) {
 				assert.Equals(t, err, nil)
 			}
 
-			if testCase.ActiveProtocol != "" {
-				assert.Equals(t, serverCtx.ActiveProtocol(), testCase.ActiveProtocol)
+			if testCase.ActiveServerProtocol != "" {
+				assert.Equals(t, serverCtx.ActiveProtocol(), testCase.ActiveServerProtocol)
+				assert.Equals(t, client.ActiveProtocol(), serverCtx.ActiveProtocol())
 			}
 		})
 	}

--- a/context_test.go
+++ b/context_test.go
@@ -87,10 +87,10 @@ func TestServerAbruptlyCloseConnectionBehavior(t *testing.T) {
 
 	// ----------------- Setup Echo Client ----------------------------------------
 
-	blipContextEchoClient := NewContext()
+	blipContextEchoClient := NewContext(BlipTestAppProtocolId)
 	port := listener.Addr().(*net.TCPAddr).Port
 	destUrl := fmt.Sprintf("ws://localhost:%d/TestServerAbruptlyCloseConnectionBehavior", port)
-	sender, err := blipContextEchoClient.Dial(destUrl, "http://localhost", BlipTestAppProtocolId)
+	sender, err := blipContextEchoClient.Dial(destUrl, "http://localhost")
 	if err != nil {
 		panic("Error opening WebSocket: " + err.Error())
 	}
@@ -244,10 +244,10 @@ func TestClientAbruptlyCloseConnectionBehavior(t *testing.T) {
 
 	// ----------------- Setup Echo Client ----------------------------------------
 
-	blipContextEchoClient := NewContext()
+	blipContextEchoClient := NewContext(BlipTestAppProtocolId)
 	port := listener.Addr().(*net.TCPAddr).Port
 	destUrl := fmt.Sprintf("ws://localhost:%d/TestClientAbruptlyCloseConnectionBehavior", port)
-	sender, err := blipContextEchoClient.Dial(destUrl, "http://localhost", BlipTestAppProtocolId)
+	sender, err := blipContextEchoClient.Dial(destUrl, "http://localhost")
 	if err != nil {
 		panic("Error opening WebSocket: " + err.Error())
 	}
@@ -399,10 +399,10 @@ func TestUnsupportedSubProtocol(t *testing.T) {
 			}()
 
 			// Client
-			client := NewContext()
+			client := NewContext(testCase.ClientProtocol...)
 			port := listener.Addr().(*net.TCPAddr).Port
 			destUrl := fmt.Sprintf("ws://localhost:%d/someBlip", port)
-			_, err = client.Dial(destUrl, "http://localhost", testCase.ClientProtocol...)
+			_, err = client.Dial(destUrl, "http://localhost")
 
 			if testCase.ExpectError {
 				assert.True(t, err != nil)

--- a/example/cmd/responder.go
+++ b/example/cmd/responder.go
@@ -11,9 +11,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-
 const (
-	verbosity = 0
+	verbosity  = 0
 	kInterface = ":12345"
 
 	// The application protocol id of the BLIP websocket subprotocol used by go-blip examples
@@ -41,7 +40,10 @@ func responder() {
 	runtime.GOMAXPROCS(maxProcs)
 	log.Printf("Set GOMAXPROCS to %d", maxProcs)
 
-	context := blip.NewContext(BlipExampleAppProtocolId)
+	context, err := blip.NewContext(BlipExampleAppProtocolId)
+	if err != nil {
+		panic(err)
+	}
 	context.HandlerForProfile["BLIPTest/EchoData"] = dispatchEcho
 	context.LogMessages = verbosity > 1
 	context.LogFrames = verbosity > 2
@@ -51,7 +53,7 @@ func responder() {
 
 	http.Handle("/test", context.HTTPHandler())
 	log.Printf("Listening on %s/test", kInterface)
-	err := http.ListenAndServe(kInterface, nil)
+	err = http.ListenAndServe(kInterface, nil)
 	if err != nil {
 		panic("ListenAndServe: " + err.Error())
 	}

--- a/example/cmd/sendtest.go
+++ b/example/cmd/sendtest.go
@@ -49,7 +49,10 @@ func sender() {
 	runtime.GOMAXPROCS(maxProcs)
 	log.Printf("Set GOMAXPROCS to %d", maxProcs)
 
-	context := blip.NewContext(BlipExampleAppProtocolId)
+	context, err := blip.NewContext(BlipExampleAppProtocolId)
+	if err != nil {
+		panic(err)
+	}
 	context.MaxSendQueueCount = kMaxSendQueueCount
 	context.LogMessages = verbosity > 1
 	context.LogFrames = verbosity > 2

--- a/example/cmd/sendtest.go
+++ b/example/cmd/sendtest.go
@@ -49,11 +49,11 @@ func sender() {
 	runtime.GOMAXPROCS(maxProcs)
 	log.Printf("Set GOMAXPROCS to %d", maxProcs)
 
-	context := blip.NewContext()
+	context := blip.NewContext(BlipExampleAppProtocolId)
 	context.MaxSendQueueCount = kMaxSendQueueCount
 	context.LogMessages = verbosity > 1
 	context.LogFrames = verbosity > 2
-	sender, err := context.Dial("ws://localhost:12345/test", "http://localhost", BlipExampleAppProtocolId)
+	sender, err := context.Dial("ws://localhost:12345/test", "http://localhost")
 	if err != nil {
 		panic("Error opening WebSocket: " + err.Error())
 	}

--- a/example/cmd/sendtest.go
+++ b/example/cmd/sendtest.go
@@ -31,7 +31,6 @@ var pendingResponses map[blip.MessageNumber]bool
 var pendingCount, sentCount int
 var mutex sync.Mutex
 
-
 func init() {
 	RootCmd.AddCommand(sendCmd)
 }
@@ -50,11 +49,11 @@ func sender() {
 	runtime.GOMAXPROCS(maxProcs)
 	log.Printf("Set GOMAXPROCS to %d", maxProcs)
 
-	context := blip.NewContext(BlipExampleAppProtocolId)
+	context := blip.NewContext()
 	context.MaxSendQueueCount = kMaxSendQueueCount
 	context.LogMessages = verbosity > 1
 	context.LogFrames = verbosity > 2
-	sender, err := context.Dial("ws://localhost:12345/test", "http://localhost")
+	sender, err := context.Dial("ws://localhost:12345/test", "http://localhost", BlipExampleAppProtocolId)
 	if err != nil {
 		panic("Error opening WebSocket: " + err.Error())
 	}
@@ -187,7 +186,6 @@ func getPendingCount() int {
 	defer mutex.Unlock()
 	return pendingCount
 }
-
 
 //  Copyright (c) 2013 Jens Alfke.
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/functional_test.go
+++ b/functional_test.go
@@ -74,10 +74,10 @@ func TestEchoRoundTrip(t *testing.T) {
 
 	// ----------------- Setup Echo Client ----------------------------------------
 
-	blipContextEchoClient := NewContext(BlipTestAppProtocolId)
+	blipContextEchoClient := NewContext()
 	port := listener.Addr().(*net.TCPAddr).Port
 	destUrl := fmt.Sprintf("ws://localhost:%d/blip", port)
-	sender, err := blipContextEchoClient.Dial(destUrl, "http://localhost")
+	sender, err := blipContextEchoClient.Dial(destUrl, "http://localhost", BlipTestAppProtocolId)
 	if err != nil {
 		panic("Error opening WebSocket: " + err.Error())
 	}
@@ -146,7 +146,7 @@ func TestSenderPing(t *testing.T) {
 	}()
 
 	// client
-	clientCtx := NewContext(BlipTestAppProtocolId)
+	clientCtx := NewContext()
 	clientCtx.LogMessages = true
 	clientCtx.LogFrames = true
 	clientCtx.WebsocketPingInterval = time.Millisecond * 10
@@ -158,7 +158,7 @@ func TestSenderPing(t *testing.T) {
 	assert.Equals(t, expvarToInt64(goblipExpvar.Get("sender_ping_count")), int64(0))
 	assert.Equals(t, expvarToInt64(goblipExpvar.Get("goroutines_sender_ping")), int64(0))
 
-	sender, err := clientCtx.Dial(destUrl, "http://localhost")
+	sender, err := clientCtx.Dial(destUrl, "http://localhost", BlipTestAppProtocolId)
 	if err != nil {
 		panic("Error opening WebSocket: " + err.Error())
 	}

--- a/functional_test.go
+++ b/functional_test.go
@@ -22,7 +22,10 @@ import (
 // aka a "functional test".
 func TestEchoRoundTrip(t *testing.T) {
 
-	blipContextEchoServer := NewContext(BlipTestAppProtocolId)
+	blipContextEchoServer, err := NewContext(BlipTestAppProtocolId)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	receivedRequests := sync.WaitGroup{}
 
@@ -74,7 +77,10 @@ func TestEchoRoundTrip(t *testing.T) {
 
 	// ----------------- Setup Echo Client ----------------------------------------
 
-	blipContextEchoClient := NewContext(BlipTestAppProtocolId)
+	blipContextEchoClient, err := NewContext(BlipTestAppProtocolId)
+	if err != nil {
+		t.Fatal(err)
+	}
 	port := listener.Addr().(*net.TCPAddr).Port
 	destUrl := fmt.Sprintf("ws://localhost:%d/blip", port)
 	sender, err := blipContextEchoClient.Dial(destUrl, "http://localhost")
@@ -126,7 +132,10 @@ func TestEchoRoundTrip(t *testing.T) {
 func TestSenderPing(t *testing.T) {
 
 	// server
-	serverCtx := NewContext(BlipTestAppProtocolId)
+	serverCtx, err := NewContext(BlipTestAppProtocolId)
+	if err != nil {
+		t.Fatal(err)
+	}
 	server := serverCtx.WebSocketServer()
 	defaultHandler := server.Handler
 	server.Handler = func(conn *websocket.Conn) {
@@ -146,7 +155,10 @@ func TestSenderPing(t *testing.T) {
 	}()
 
 	// client
-	clientCtx := NewContext(BlipTestAppProtocolId)
+	clientCtx, err := NewContext(BlipTestAppProtocolId)
+	if err != nil {
+		t.Fatal(err)
+	}
 	clientCtx.LogMessages = true
 	clientCtx.LogFrames = true
 	clientCtx.WebsocketPingInterval = time.Millisecond * 10

--- a/functional_test.go
+++ b/functional_test.go
@@ -74,10 +74,10 @@ func TestEchoRoundTrip(t *testing.T) {
 
 	// ----------------- Setup Echo Client ----------------------------------------
 
-	blipContextEchoClient := NewContext()
+	blipContextEchoClient := NewContext(BlipTestAppProtocolId)
 	port := listener.Addr().(*net.TCPAddr).Port
 	destUrl := fmt.Sprintf("ws://localhost:%d/blip", port)
-	sender, err := blipContextEchoClient.Dial(destUrl, "http://localhost", BlipTestAppProtocolId)
+	sender, err := blipContextEchoClient.Dial(destUrl, "http://localhost")
 	if err != nil {
 		panic("Error opening WebSocket: " + err.Error())
 	}
@@ -146,7 +146,7 @@ func TestSenderPing(t *testing.T) {
 	}()
 
 	// client
-	clientCtx := NewContext()
+	clientCtx := NewContext(BlipTestAppProtocolId)
 	clientCtx.LogMessages = true
 	clientCtx.LogFrames = true
 	clientCtx.WebsocketPingInterval = time.Millisecond * 10
@@ -158,7 +158,7 @@ func TestSenderPing(t *testing.T) {
 	assert.Equals(t, expvarToInt64(goblipExpvar.Get("sender_ping_count")), int64(0))
 	assert.Equals(t, expvarToInt64(goblipExpvar.Get("goroutines_sender_ping")), int64(0))
 
-	sender, err := clientCtx.Dial(destUrl, "http://localhost", BlipTestAppProtocolId)
+	sender, err := clientCtx.Dial(destUrl, "http://localhost")
 	if err != nil {
 		panic("Error opening WebSocket: " + err.Error())
 	}

--- a/protocol.go
+++ b/protocol.go
@@ -1,6 +1,9 @@
 package blip
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // WebSocket [sub]protocol prefix for BLIP, used during WebSocket handshake.
 // Client request must indicate that it supports this protocol, else the handshake will fail.
@@ -71,9 +74,26 @@ func (f frameFlags) messageType() MessageType {
 
 ///////// HELPER UTILS:
 
+func FormatWebSocketSubProtocols(AppProtocolIds ...string) []string {
+	formattedProtocols := make([]string, len(AppProtocolIds))
+	for i, protocol := range AppProtocolIds {
+		formattedProtocols[i] = NewWebSocketSubProtocol(protocol)
+	}
+	return formattedProtocols
+}
+
 // Create a new Websocket subprotocol using the given application protocol identifier.
 func NewWebSocketSubProtocol(AppProtocolId string) string {
 	return fmt.Sprintf("%s+%s", WebSocketSubProtocolPrefix, AppProtocolId)
+}
+
+// Extracts subprotocol from the above format
+func ExtractAppProtocolId(protocol string) string {
+	splitString := strings.SplitN(protocol, "+", 2)
+	if len(splitString) == 2 {
+		return splitString[1]
+	}
+	return ""
 }
 
 //  Copyright (c) 2013 Jens Alfke. Copyright (c) 2015-2017 Couchbase, Inc.


### PR DESCRIPTION
Allows multiple protocols to be passed in when creating a NewContext. This means a host can specify multiple supported versions allowing sub protocols to be updated whilst still being backwards compatible for older clients.

For hosts NewContext should have subprotocols passed in which it can support.
For clients NewContext should have subprotocols passed in which it can support but should be ordered so that the preferred method is first.

ActiveProtocol returns the protocol set in the format passed in (doesn't have the BLIPV3 tagged onto it).