### PR TITLE
CBG-1517 Store the currently used Websocket subprotocol on BLIP context

### DIFF
--- a/context.go
+++ b/context.go
@@ -77,7 +77,7 @@ func NewContextCustomID(id string, appProtocolIds ...string) (*Context, error) {
 		HandlerForProfile:     map[string]Handler{},
 		Logger:                logPrintfWrapper(),
 		ID:                    id,
-		SupportedSubProtocols: FormatWebSocketSubProtocols(appProtocolIds...),
+		SupportedSubProtocols: formatWebSocketSubProtocols(appProtocolIds...),
 	}, nil
 }
 
@@ -141,7 +141,7 @@ func (context *Context) DialConfig(config *websocket.Config) (*Sender, error) {
 			}
 		}
 	}()
-	context.activeSubProtocol = ExtractAppProtocolId(selectedSubProtocol)
+	context.activeSubProtocol = extractAppProtocolId(selectedSubProtocol)
 	return sender, nil
 }
 
@@ -163,7 +163,7 @@ func (context *Context) WebSocketHandshake() WSHandshake {
 		}
 
 		config.Protocol = []string{protocol}
-		context.activeSubProtocol = ExtractAppProtocolId(protocol)
+		context.activeSubProtocol = extractAppProtocolId(protocol)
 		return nil
 	}
 }

--- a/context.go
+++ b/context.go
@@ -141,7 +141,7 @@ func (context *Context) DialConfig(config *websocket.Config) (*Sender, error) {
 			}
 		}
 	}()
-	context.activeSubProtocol = selectedSubProtocol
+	context.activeSubProtocol = ExtractAppProtocolId(selectedSubProtocol)
 	return sender, nil
 }
 
@@ -163,7 +163,7 @@ func (context *Context) WebSocketHandshake() WSHandshake {
 		}
 
 		config.Protocol = []string{protocol}
-		context.activeSubProtocol = protocol
+		context.activeSubProtocol = ExtractAppProtocolId(protocol)
 		return nil
 	}
 }
@@ -171,7 +171,7 @@ func (context *Context) WebSocketHandshake() WSHandshake {
 // ActiveProtocol returns the currently used WebSocket subprotocol for the Context, set after a successful handshake in
 // the case of a host or a successful Dial in the case of a client.
 func (context *Context) ActiveProtocol() string {
-	return ExtractAppProtocolId(context.activeSubProtocol)
+	return context.activeSubProtocol
 }
 
 // Creates a WebSocket connection handler that dispatches BLIP messages to the Context.

--- a/protocol.go
+++ b/protocol.go
@@ -74,7 +74,7 @@ func (f frameFlags) messageType() MessageType {
 
 ///////// HELPER UTILS:
 
-func FormatWebSocketSubProtocols(AppProtocolIds ...string) []string {
+func formatWebSocketSubProtocols(AppProtocolIds ...string) []string {
 	formattedProtocols := make([]string, len(AppProtocolIds))
 	for i, protocol := range AppProtocolIds {
 		formattedProtocols[i] = NewWebSocketSubProtocol(protocol)
@@ -88,7 +88,7 @@ func NewWebSocketSubProtocol(AppProtocolId string) string {
 }
 
 // Extracts subprotocol from the above format
-func ExtractAppProtocolId(protocol string) string {
+func extractAppProtocolId(protocol string) string {
 	splitString := strings.SplitN(protocol, "+", 2)
 	if len(splitString) == 2 {
 		return splitString[1]


### PR DESCRIPTION
ActiveProtocol is a relatively expensive call (it's doing strings.SplitN every time), so it sounds reasonable to store the currently used Websocket subprotocol on BLIP context.