### PR TITLE
CBG-1517 Rename ActiveProtocol to ActiveSubprotocol

### DIFF
--- a/context.go
+++ b/context.go
@@ -168,9 +168,9 @@ func (context *Context) WebSocketHandshake() WSHandshake {
 	}
 }
 
-// ActiveProtocol returns the currently used WebSocket subprotocol for the Context, set after a successful handshake in
+// ActiveSubprotocol returns the currently used WebSocket subprotocol for the Context, set after a successful handshake in
 // the case of a host or a successful Dial in the case of a client.
-func (context *Context) ActiveProtocol() string {
+func (context *Context) ActiveSubprotocol() string {
 	return context.activeSubProtocol
 }
 

--- a/context_test.go
+++ b/context_test.go
@@ -437,8 +437,8 @@ func TestUnsupportedSubProtocol(t *testing.T) {
 			}
 
 			if testCase.ActiveServerProtocol != "" {
-				assert.Equals(t, serverCtx.ActiveProtocol(), testCase.ActiveServerProtocol)
-				assert.Equals(t, client.ActiveProtocol(), serverCtx.ActiveProtocol())
+				assert.Equals(t, serverCtx.ActiveSubprotocol(), testCase.ActiveServerProtocol)
+				assert.Equals(t, client.ActiveSubprotocol(), serverCtx.ActiveSubprotocol())
 			}
 		})
 	}


### PR DESCRIPTION
Changes to rename ActiveProtocol to ActiveSubprotocol.