### PR TITLE
CBG-1712: Replaced std compress/flate with third party

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -12,12 +12,16 @@ package blip
 
 import (
 	"bytes"
-	"compress/flate"
 	"fmt"
 	"hash"
 	"hash/crc32"
 	"io"
 	"sync"
+
+	// CBG-1712: std compress/flate has some sort of issue
+	// handling the compressed stream of BLIP data that this
+	// library does not
+	"github.com/klauspost/compress/flate"
 )
 
 // The standard trailer appended by 'deflate' when flushing its output. BLIP (like many protocols)

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,13 @@ module github.com/couchbase/go-blip
 go 1.17
 
 require (
+	github.com/klauspost/compress v1.15.11
 	github.com/stretchr/testify v1.4.0
 	nhooyr.io/websocket v1.8.7
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/klauspost/compress v1.10.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,9 @@ github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvK
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGns=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
-github.com/klauspost/compress v1.10.3 h1:OP96hzwJVBIHYU52pVTI6CczrxPvrGfgqF9N5eTO0Q8=
 github.com/klauspost/compress v1.10.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/compress v1.15.11 h1:Lcadnb3RKGin4FYM/orgq0qde+nc15E5Cbqg4B9Sx9c=
+github.com/klauspost/compress v1.15.11/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=


### PR DESCRIPTION
Not only does it claim to be optimized, it does not appear to suffer from the same bug as the std one does (see JIRA for more info)