### PR TITLE
Add isCloseError helper and use it to lower log level of expected close 'errors'

### DIFF
--- a/receiver.go
+++ b/receiver.go
@@ -76,8 +76,9 @@ func (r *receiver) receiveLoop() error {
 		// Receive the next raw WebSocket frame:
 		_, frame, err := r.conn.Read(context.TODO())
 		if err != nil {
-			if err == io.EOF {
-				r.context.logFrame("receiveLoop stopped")
+			if isCloseError(err) {
+				// lower log level for close
+				r.context.logFrame("receiveLoop stopped: %v", err)
 			} else if parseErr := errorFromChannel(r.parseError); parseErr != nil {
 				err = parseErr
 			} else {


### PR DESCRIPTION
The old websocket library used `io.EOF` to signal websocket closures, as it could not handle status codes.

The new library does not use `io.EOF`, and we need to check the close handshake status to continue conditionally logging close messages.