### PR TITLE
Add bytes transferred stat

### DIFF
--- a/context.go
+++ b/context.go
@@ -61,8 +61,8 @@ type Context struct {
 	// An identifier that uniquely defines the context.  NOTE: Random Number Generator not seeded by go-blip.
 	ID string
 
-	lastBytesSent     atomic.Uint64 // Number of bytes sent since last query
-	lastBytesRecieved atomic.Uint64 // Number of bytes received since last query
+	bytesSent     atomic.Uint64 // Number of bytes sent
+	bytesReceived atomic.Uint64 // Number of bytes received
 }
 
 // Defines a logging interface for use within the blip codebase.  Implemented by Context.
@@ -111,9 +111,14 @@ func (context *Context) Dial(url string) (*Sender, error) {
 	})
 }
 
-// GetLastBytesTransferred returns the number of bytes since the last query of this function
-func (context *Context) GetLastBytesTransferred() uint64 {
-	return context.lastBytesRecieved.Swap(0) + context.lastBytesSent.Swap(0)
+// GetBytesSent returns the number of bytes sent since start of the context.
+func (context *Context) GetBytesSent() uint64 {
+	return context.bytesSent.Load()
+}
+
+// GetBytesReceived returns the number of bytes received since start of the context.
+func (context *Context) GetBytesReceived() uint64 {
+	return context.bytesReceived.Load()
 }
 
 // DialOptions is used by DialConfig to oepn a BLIP connection.

--- a/context.go
+++ b/context.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"runtime/debug"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"nhooyr.io/websocket"
@@ -59,6 +60,9 @@ type Context struct {
 
 	// An identifier that uniquely defines the context.  NOTE: Random Number Generator not seeded by go-blip.
 	ID string
+
+	lastBytesSent     atomic.Uint64 // Number of bytes sent since last query
+	lastBytesRecieved atomic.Uint64 // Number of bytes received since last query
 }
 
 // Defines a logging interface for use within the blip codebase.  Implemented by Context.
@@ -105,6 +109,11 @@ func (context *Context) Dial(url string) (*Sender, error) {
 	return context.DialConfig(&DialOptions{
 		URL: url,
 	})
+}
+
+// GetLastBytesTransferred returns the number of bytes since the last query of this function
+func (context *Context) GetLastBytesTransferred() uint64 {
+	return context.lastBytesRecieved.Swap(0) + context.lastBytesSent.Swap(0)
 }
 
 // DialOptions is used by DialConfig to oepn a BLIP connection.

--- a/receiver.go
+++ b/receiver.go
@@ -112,7 +112,7 @@ func (r *receiver) parseLoop() {
 	atomic.AddInt32(&r.activeGoroutines, 1)
 
 	for frame := range r.channel {
-		r.context.lastBytesRecieved.Add(uint64(len(frame)))
+		r.context.bytesReceived.Add(uint64(len(frame)))
 		if err := r.handleIncomingFrame(frame); err != nil {
 			r.fatalError(err)
 			break

--- a/receiver.go
+++ b/receiver.go
@@ -112,6 +112,7 @@ func (r *receiver) parseLoop() {
 	atomic.AddInt32(&r.activeGoroutines, 1)
 
 	for frame := range r.channel {
+		r.context.lastBytesRecieved.Add(uint64(len(frame)))
 		if err := r.handleIncomingFrame(frame); err != nil {
 			r.fatalError(err)
 			break

--- a/sender.go
+++ b/sender.go
@@ -159,7 +159,7 @@ func (sender *Sender) start() {
 			}
 
 			body, flags := msg.nextFrameToSend(maxSize - 10)
-
+			sender.context.lastBytesSent.Add(uint64(len(body)))
 			sender.context.logFrame("Sending frame: %v (flags=%8b, size=%5d)", msg, flags, len(body))
 			var header [2 * binary.MaxVarintLen64]byte
 			i := binary.PutUvarint(header[:], uint64(msg.number))

--- a/sender.go
+++ b/sender.go
@@ -159,7 +159,7 @@ func (sender *Sender) start() {
 			}
 
 			body, flags := msg.nextFrameToSend(maxSize - 10)
-			sender.context.lastBytesSent.Add(uint64(len(body)))
+			sender.context.bytesSent.Add(uint64(len(body)))
 			sender.context.logFrame("Sending frame: %v (flags=%8b, size=%5d)", msg, flags, len(body))
 			var header [2 * binary.MaxVarintLen64]byte
 			i := binary.PutUvarint(header[:], uint64(msg.number))


### PR DESCRIPTION
Use separate stats for reciever and sender, the idea is to have minimal locking so sync gateway can consume this data. 