### PR TITLE
Add WaitUntilStarted() on BlipWebsocketServer

### DIFF
--- a/context.go
+++ b/context.go
@@ -195,17 +195,30 @@ func (context *Context) ActiveSubprotocol() string {
 	return context.activeSubProtocol
 }
 
-type blipWebsocketServer struct {
-	blipCtx *Context
+type BlipWebsocketServer struct {
+	blipCtx              *Context
+	wsHandshakeCompleted chan struct{} // closed once websocket upgrade finishes
 }
+
+var _ http.Handler = &BlipWebsocketServer{}
 
 // Creates an HTTP handler that accepts WebSocket connections and dispatches BLIP messages
 // to the Context.
-func (context *Context) WebSocketServer() http.Handler {
-	return &blipWebsocketServer{blipCtx: context}
+func (context *Context) WebSocketServer() *BlipWebsocketServer {
+	return &BlipWebsocketServer{blipCtx: context, wsHandshakeCompleted: make(chan struct{})}
 }
 
-func (bwss *blipWebsocketServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+// WaitUntilStarted blocks until go-blip is ready to start handling BLIP messages.
+func (bwss *BlipWebsocketServer) WaitUntilStarted(ctx gocontext.Context) bool {
+	select {
+	case <-bwss.wsHandshakeCompleted:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func (bwss *BlipWebsocketServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ws, err := bwss.handshake(w, r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -214,7 +227,7 @@ func (bwss *blipWebsocketServer) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	bwss.handle(ws)
 }
 
-func (bwss *blipWebsocketServer) handshake(w http.ResponseWriter, r *http.Request) (*websocket.Conn, error) {
+func (bwss *BlipWebsocketServer) handshake(w http.ResponseWriter, r *http.Request) (*websocket.Conn, error) {
 	protocolHeader := r.Header.Get("Sec-WebSocket-Protocol")
 	protocol, found := includesProtocol(protocolHeader, bwss.blipCtx.SupportedSubProtocols)
 	if !found {
@@ -234,10 +247,12 @@ func (bwss *blipWebsocketServer) handshake(w http.ResponseWriter, r *http.Reques
 	}
 
 	bwss.blipCtx.activeSubProtocol = extractAppProtocolId(protocol)
+
+	close(bwss.wsHandshakeCompleted)
 	return ws, nil
 }
 
-func (bwss *blipWebsocketServer) handle(ws *websocket.Conn) {
+func (bwss *BlipWebsocketServer) handle(ws *websocket.Conn) {
 	bwss.blipCtx.log("Start BLIP/Websocket handler")
 	sender := bwss.blipCtx.start(ws)
 	err := sender.receiver.receiveLoop()


### PR DESCRIPTION
Allows consumers (SG) to be notified that the websocket upgrade and subprotocol handshake are done.

Example usage:

```go
	// Create a BLIP WebSocket handler and have it handle the request:
	server := blipContext.WebSocketServer()

	go func() {
		if ok := server.WaitUntilStarted(h.ctx()); !ok {
			base.InfofCtx(h.ctx(), base.KeyHTTP, "BLIP+WebSocket connection closed before upgrade")
			return
		}

		subprotocol := blipContext.ActiveSubprotocol()
		h.logStatus(http.StatusSwitchingProtocols, fmt.Sprintf("[%s] Upgraded to WebSocket protocol %s+%s%s", blipContext.ID, blip.WebSocketSubProtocolPrefix, subprotocol, h.formattedEffectiveUserName()))
	}()
```