### PR TITLE
Appropriately use returned error in PostHandshakeCallback handling

### DIFF
--- a/context.go
+++ b/context.go
@@ -219,7 +219,9 @@ func (bwss *BlipWebsocketServer) ServeHTTP(w http.ResponseWriter, r *http.Reques
 
 func (bwss *BlipWebsocketServer) handshake(w http.ResponseWriter, r *http.Request) (conn *websocket.Conn, err error) {
 	if bwss.PostHandshakeCallback != nil {
-		defer bwss.PostHandshakeCallback(err)
+		defer func() {
+			bwss.PostHandshakeCallback(err)
+		}()
 	}
 
 	protocolHeader := r.Header.Get("Sec-WebSocket-Protocol")


### PR DESCRIPTION
Fix accidental regression in https://github.com/couchbase/go-blip/pull/69