### PR TITLE
CBG-3652 check Origin header in websocket library

### DIFF
--- a/context.go
+++ b/context.go
@@ -219,7 +219,9 @@ func (bwss *BlipWebsocketServer) ServeHTTP(w http.ResponseWriter, r *http.Reques
 
 func (bwss *BlipWebsocketServer) handshake(w http.ResponseWriter, r *http.Request) (conn *websocket.Conn, err error) {
 	if bwss.PostHandshakeCallback != nil {
-		defer bwss.PostHandshakeCallback(err)
+		defer func() {
+			bwss.PostHandshakeCallback(err)
+		}()
 	}
 
 	protocolHeader := r.Header.Get("Sec-WebSocket-Protocol")

--- a/context.go
+++ b/context.go
@@ -46,7 +46,7 @@ type Context struct {
 	// The currently used WebSocket subprotocol by the client, set on a successful handshake.
 	activeSubProtocol string
 
-	// Regular expressions that the Origin header must match (if non-empty)
+	// Patterns that the Origin header must match (if non-empty)
 	origin []string
 
 	HandlerForProfile   map[string]Handler                                // Handler function for a request Profile
@@ -82,7 +82,7 @@ type LogContext interface {
 type ContextOptions struct {
 	// The WebSocket subprotocols that this blip context is constrained to. Eg: BLIP_3+CBMobile_2
 	ProtocolIds []string
-	// Regular expressions that the Origin header must match (if non-empty). This matches only on hostname: ["example.com", "*"]
+	// Patterns that the Origin header must match (if non-empty). This matches only on hostname: ["example.com", "*"]
 	Origin []string
 }
 

--- a/context_test.go
+++ b/context_test.go
@@ -27,8 +27,6 @@ import (
 // The application protocol id of the BLIP websocket subprotocol used in go-blip unit tests
 const BlipTestAppProtocolId = "GoBlipUnitTests"
 
-var emptyOrigin = []string{}
-
 var defaultContextOptions = ContextOptions{ProtocolIds: []string{BlipTestAppProtocolId}}
 
 // This was added in reaction to https://github.com/couchbase/sync_gateway/issues/3268 to either

--- a/context_test.go
+++ b/context_test.go
@@ -476,38 +476,42 @@ func TestOrigin(t *testing.T) {
 	protocol := "Protocol1"
 	testCases := []struct {
 		serverOrigin  []string
-		requestOrigin string
+		requestOrigin *string
 		hasError      bool
 	}{
 		{
 			serverOrigin:  []string{"example.com"},
-			requestOrigin: "https://example.com",
+			requestOrigin: StringPtr("https://example.com"),
 		},
 		{
 			serverOrigin:  []string{"foobar.com", "example.com"},
-			requestOrigin: "https://example.com",
+			requestOrigin: StringPtr("https://example.com"),
 		},
 		{
 			serverOrigin:  []string{"*"},
-			requestOrigin: "https://example.com",
+			requestOrigin: StringPtr("https://example.com"),
 		},
 		{
 			serverOrigin:  []string{"*"},
-			requestOrigin: "ws://example.com",
+			requestOrigin: StringPtr("ws://example.com"),
 		},
 		{
 			serverOrigin:  []string{"*"},
-			requestOrigin: "wss://example.com",
+			requestOrigin: StringPtr("wss://example.com"),
 		},
 		{
 			serverOrigin:  []string{"example.com"},
-			requestOrigin: "wss://example.org",
+			requestOrigin: StringPtr("wss://example.org"),
 			hasError:      true,
 		},
 		{
 			serverOrigin:  []string{""},
-			requestOrigin: "wss://example.org",
+			requestOrigin: StringPtr("wss://example.org"),
 			hasError:      true,
+		},
+		{
+			serverOrigin:  []string{"example.com"},
+			requestOrigin: nil,
 		},
 	}
 	for _, test := range testCases {
@@ -550,9 +554,10 @@ func TestOrigin(t *testing.T) {
 			config := DialOptions{
 				URL: destUrl,
 			}
-			config.HTTPHeader = make(http.Header)
-			config.HTTPHeader.Add("Origin", test.requestOrigin)
-
+			if test.requestOrigin != nil {
+				config.HTTPHeader = make(http.Header)
+				config.HTTPHeader.Add("Origin", *test.requestOrigin)
+			}
 			sender, err := client.DialConfig(&config)
 			if test.hasError {
 				require.Error(t, err)
@@ -612,4 +617,9 @@ func WaitWithTimeout(wg *sync.WaitGroup, timeout time.Duration) error {
 		return fmt.Errorf("Timed out waiting after %v", timeout)
 	}
 
+}
+
+// StringPtr returns a pointer to the string value passed in
+func StringPtr(s string) *string {
+	return &s
 }

--- a/functional_test.go
+++ b/functional_test.go
@@ -31,7 +31,7 @@ import (
 // aka a "functional test".
 func TestEchoRoundTrip(t *testing.T) {
 
-	blipContextEchoServer, err := NewContext(BlipTestAppProtocolId)
+	blipContextEchoServer, err := NewContext(defaultContextOptions)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +79,7 @@ func TestEchoRoundTrip(t *testing.T) {
 
 	// ----------------- Setup Echo Client ----------------------------------------
 
-	blipContextEchoClient, err := NewContext(BlipTestAppProtocolId)
+	blipContextEchoClient, err := NewContext(defaultContextOptions)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -135,7 +135,7 @@ func TestEchoRoundTrip(t *testing.T) {
 func TestSenderPing(t *testing.T) {
 
 	// server
-	serverCtx, err := NewContext(BlipTestAppProtocolId)
+	serverCtx, err := NewContext(defaultContextOptions)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -152,7 +152,7 @@ func TestSenderPing(t *testing.T) {
 	}()
 
 	// client
-	clientCtx, err := NewContext(BlipTestAppProtocolId)
+	clientCtx, err := NewContext(defaultContextOptions)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Enable checking the Origin header the websocket library. 

This works on top of https://github.com/couchbase/go-blip/pull/70.

Odd things about this code:

- Unlike how you pass `Origin` header, the websocket library expects hostnames without URLs, it matches on `u.Host`, so `example.com` instead of `wss://example.com` or `ws://example.com`. Other things that match `*` are allowed. This mostly has consequences in the Sync Gateway review, since we have to convert our structures.
- Because I added a `[]string` option to `NewContext` I changed the calling code to use an options struct since I keep messing up the API that was `NewContext(origin []string, protocols... string)`. I'm not committed to the API I picked at all, it was to prevent my mistakes.