### PR TITLE
update golangci-lint/github workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.8
+          go-version: 1.23.5
       - run: go install github.com/google/addlicense@latest
       - run: addlicense -check -f licenses/addlicense.tmpl .
 
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.8
+          go-version: 1.23.5
       - name: Build
         run: go build -v "./..."
       - name: Run Tests
@@ -51,7 +51,7 @@ jobs:
         shell: bash
       - name: Annotate Failures
         if: always()
-        uses: guyarb/golang-test-annotations@v0.6.0
+        uses: guyarb/golang-test-annotations@v0.8.0
         with:
           test-results: test.json
 
@@ -64,7 +64,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.61.0
+          version: v1.63.4
 
   test-race:
     runs-on: ubuntu-latest
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.8
+          go-version: 1.23.5
       - name: Run Tests
         run: go test -race -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
         shell: bash
@@ -91,7 +91,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.8
+          go-version: 1.23.5
       - name: Build
         run: cd example && go build -v "./..."
     permissions:
@@ -110,5 +110,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.61.0
+          version: v1.63.4
           working-directory: example

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,9 +11,9 @@
 linters:
   enable:
     #- bodyclose # checks whether HTTP response body is closed successfully
-    #- dupl # Tool for code clone detection
+    - dupl # Tool for code clone detection
     - errcheck # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases
-    #- goconst # Finds repeated strings that could be replaced by a constant
+    # - goconst # Finds repeated strings that could be replaced by a constant
     #- gocritic # The most opinionated Go source code linter
     - goimports # Goimports does everything that gofmt does. Additionally it checks unused imports
     #- goprintffuncname # Checks that printf-like functions are named with `f` at the end
@@ -21,52 +21,18 @@ linters:
     #- gosimple # (megacheck) Linter for Go source code that specializes in simplifying a code
     - govet # (vet, vetshadow) Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
     - ineffassign # Detects when assignments to existing variables are not used
-    #- nakedret # Finds naked returns in functions greater than a specified function length
-    #- prealloc # Finds slice declarations that could potentially be preallocated
-    #- revive # Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes
-    - staticcheck # (megacheck) Staticcheck is a go vet on steroids, applying a ton of static analysis checks
-    #- structcheck # Finds unused struct fields
-    - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code
-    #- unconvert # Remove unnecessary type conversions
-    #- unparam # Reports unused function parameters
-    #- unused # (megacheck) Checks Go code for unused constants, variables, functions and types
-  disable:
-    - asciicheck # Simple linter to check that your code does not contain non-ASCII identifiers
-    - depguard # Go linter that checks if package imports are in a list of acceptable packages
-    - dogsled # Checks assignments with too many blank identifiers # (e.g. x, _, _, _, := f())
-    - funlen # Tool for detection of long functions
-    - gochecknoglobals # Checks that no globals are present in Go code
-    - gochecknoinits # Checks that no init functions are present in Go code
-    - gocognit # Computes and checks the cognitive complexity of functions
-    - gocyclo # Computes and checks the cyclomatic complexity of functions
-    - godot # Check if comments end in a period
-    - godox # Tool for detection of FIXME, TODO and other comment keywords
-    - gofmt # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
-    - gomnd # An analyzer to detect magic numbers.
-    - gomodguard # Allow and block list linter for direct Go module dependencies.
-    - lll # Reports long lines
     - misspell # Finds commonly misspelled English words in comments
-    - nestif # Reports deeply nested if statements
-    - nolintlint # Reports ill-formed or insufficient nolint directives
-    - rowserrcheck # checks whether Err of rows is checked successfully
-    - stylecheck # Stylecheck is a replacement for golint
-    - testpackage # linter that makes you use a separate _test package
-    - unused # (megacheck) Checks Go code for unused constants, variables, functions and types
-    - whitespace # Tool for detection of leading and trailing whitespace
-    - wsl # Whitespace Linter - Forces you to use empty lines!
-    # Once fixed, should enable
-    - bodyclose # checks whether HTTP response body is closed successfully
-    - dupl # Tool for code clone detection
-    - goconst # Finds repeated strings that could be replaced by a constant
-    - gocritic # The most opinionated Go source code linter
-    - goprintffuncname # Checks that printf-like functions are named with `f` at the end
-    - gosec # (gas) Inspects source code for security problems
-    - gosimple # (megacheck) Linter for Go source code that specializes in simplifying a code
     - nakedret # Finds naked returns in functions greater than a specified function length
     - prealloc # Finds slice declarations that could potentially be preallocated
-    - revive # Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes
-    - unconvert # Remove unnecessary type conversions
+    #- revive # Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes
+    - staticcheck # (megacheck) Staticcheck is a go vet on steroids, applying a ton of static analysis checks
+    - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code
+    #- unconvert # Remove unnecessary type conversions
     - unparam # Reports unused function parameters
+    #- unused # (megacheck) Checks Go code for unused constants, variables, functions and types
+  disable:
+    - gosimple # (megacheck) Linter for Go source code that specializes in simplifying a code
+    - unused # (megacheck) Checks Go code for unused constants, variables, functions and types
 
 # Don't enable fieldalignment, changing the field alignment requires checking to see if anyone uses constructors
 # without names. If there is a memory issue on a specific field, that is best found with a heap profile.


### PR DESCRIPTION
- use go 1.23.5 to match Sync Gateway
- update golangci-lint versions
- remove deprecated linters in .golanci.yml, only explicitly disable linters that are active

preparing to add some new code that using `atomic` package primitives and updating go.mod 1.23