### PR TITLE
CBG-4572: close all messages in iceBox map when sender is closed

### DIFF
--- a/sender_test.go
+++ b/sender_test.go
@@ -1,3 +1,13 @@
+/*
+Copyright 2025-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+*/
+
 package blip
 
 import (

--- a/sender_test.go
+++ b/sender_test.go
@@ -1,0 +1,61 @@
+package blip
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStopSenderClearsAllMessageQueues(t *testing.T) {
+	blipContextEchoServer, err := NewContext(defaultContextOptions)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := blipContextEchoServer.WebSocketServer()
+	http.Handle("/TestStopSenderClearsAllMessageQueues", server)
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		t.Error(http.Serve(listener, nil))
+	}()
+
+	blipContextEchoClient, err := NewContext(defaultContextOptions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	destUrl := fmt.Sprintf("ws://localhost:%d/TestStopSenderClearsAllMessageQueues", port)
+	sender, err := blipContextEchoClient.Dial(destUrl)
+	if err != nil {
+		t.Fatalf("Error opening WebSocket: %v", err)
+	}
+
+	// Add some messages to the queue + icebox queue
+	for i := 0; i < 10; i++ {
+		msgProp := Properties{
+			"id": fmt.Sprint(i),
+		}
+		sender.queue.push(&Message{Properties: msgProp, Outgoing: true})
+	}
+	for i := 10; i < 15; i++ {
+		msgProp := Properties{
+			"id": fmt.Sprint(i),
+		}
+		msg := &Message{Properties: msgProp}
+		sender.icebox[msgKey{msgNo: MessageNumber(i)}] = msg
+	}
+
+	// close sender
+	sender.Close()
+
+	// assert both icebox and queue is empty
+	assert.Equal(t, 0, len(sender.queue.queue))
+	assert.Equal(t, 0, len(sender.icebox))
+
+}

--- a/sender_test.go
+++ b/sender_test.go
@@ -38,16 +38,19 @@ func TestStopSenderClearsAllMessageQueues(t *testing.T) {
 
 	// Add some messages to the queue + icebox queue
 	for i := 0; i < 10; i++ {
+		msg := NewRequest()
 		msgProp := Properties{
 			"id": fmt.Sprint(i),
 		}
-		sender.queue.push(&Message{Properties: msgProp, Outgoing: true})
+		msg.Properties = msgProp
+		sender.queue.push(msg)
 	}
 	for i := 10; i < 15; i++ {
+		msg := NewRequest()
 		msgProp := Properties{
 			"id": fmt.Sprint(i),
 		}
-		msg := &Message{Properties: msgProp}
+		msg.Properties = msgProp
 		sender.icebox[msgKey{msgNo: MessageNumber(i)}] = msg
 	}
 


### PR DESCRIPTION

`nextFrameToSend` will leak goroutines if docs are large enough to be split into multiple frames and the connection goes dead CBL side but our side its still alive causing blip to queue messages in a map called iceBox when you have so many frames associated with one messages not ack’d. Then when the connection is eventually torn down, sender.stop() will iterate through the queues messages and close each message in queue but will not iterate through the icebox map to close any messages in there. 

I was able to repro the leak see below:
<img width="148" alt="Screenshot 2025-03-20 at 16 45 46" src="https://github.com/user-attachments/assets/2265eee3-9774-449a-a7bd-7cb1f71262fc" />

The fix is to iterate through icebox map to close all messages in the map when the sender is closed. This will teardown any goroutines writing to pipe in `nextFrameToSend`

