### PR TITLE
CBG-5031: fix panic for nil icebox map

### DIFF
--- a/sender.go
+++ b/sender.go
@@ -131,10 +131,11 @@ func (sender *Sender) Stop() {
 func (sender *Sender) closeIceBox() {
 	sender.requeueLock.Lock()
 	defer sender.requeueLock.Unlock()
-	for _, msg := range sender.icebox {
+	for key, msg := range sender.icebox {
 		if err := msg.Close(); err != nil {
 			sender.context.logFrame("Warning: Sender encountered error closing messages in icebox. Error: %v", err)
 		}
+		delete(sender.icebox, key)
 	}
 }
 

--- a/sender.go
+++ b/sender.go
@@ -136,7 +136,6 @@ func (sender *Sender) closeIceBox() {
 			sender.context.logFrame("Warning: Sender encountered error closing messages in icebox. Error: %v", err)
 		}
 	}
-	sender.icebox = nil
 }
 
 func (sender *Sender) Close() {


### PR DESCRIPTION
CBG-5031

Panic seems to happen when closing a sender's messages in icebox we seem to nil the icebox after. We should avoid this and just clear the messages in the icebox to avoid this panic.